### PR TITLE
fix: markdown card using summary rather than description

### DIFF
--- a/client/components/ContentDocModifiedDateTime.vue
+++ b/client/components/ContentDocModifiedDateTime.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script setup lang="ts">
-import { DateTime } from 'luxon'
+import type { DateTime } from 'luxon'
 
 type Props = {
   modifiedDateTime: DateTime

--- a/client/components/MarkdownCard.vue
+++ b/client/components/MarkdownCard.vue
@@ -1,8 +1,8 @@
 <template>
   <Card :href="props.id" heading-level="3" has-cover-link>
     <template #headingTitle>{{ page?.title }} {{ error }}</template>
-    <p v-if="summary" class="text-base mt-2 text-blue-900 dark:text-white">
-      {{ summary }}
+    <p v-if="description" class="text-base mt-2 text-blue-900 dark:text-white">
+      {{ description }}
     </p>
   </Card>
 </template>
@@ -21,5 +21,5 @@ const { error, data: page } = await useAsyncData(props.id, () =>
   queryCollection('content').path(props.id).first()
 )
 
-const summary = page.value?.summary
+const description = computed(() => page.value?.description)
 </script>

--- a/client/pages/[...slug].vue
+++ b/client/pages/[...slug].vue
@@ -17,10 +17,10 @@
 </template>
 
 <script setup lang="ts">
+import { provide } from 'vue'
 import { DateTime } from 'luxon'
 import _contentMetadata from '../generated/content-metadata.json'
 import type { ContentMetadata } from '~/modules/generate-content-metadata'
-import { provide } from 'vue'
 import type { BreadcrumbItem } from '~/components/BreadcrumbsTypes'
 import {
   nuxtContentTocToRfcEditorToc,


### PR DESCRIPTION
## fix

* New bug! The Nuxt Content config changed to use `description` (from `summary`) to better match SEO terms but this component was missed.
