### PR TITLE
feat: search 'sort by' with native select

### DIFF
--- a/client/components/SearchSortBy.vue
+++ b/client/components/SearchSortBy.vue
@@ -26,38 +26,19 @@
       ]"
     >
       <template #default="{ items, currentRefinement, refine }">
-        <select-root
+        <Select
           :model-value="currentRefinement"
-          @update:model-value="val => refine(val)"
+          @update:model-value="(val) => refine(val)"
+        >
+          <option
+            v-for="item of items"
+            :key="item.value"
+            :value="item.value"
+            class="flex items-center pl-[20px] cursor-pointer hover:bg-gray-300 dark:hover:bg-gray-700"
           >
-          <select-trigger
-            class="flex items-center px-3 h-[37px] bg-white text-base border border-gray-400 dark:bg-black dark:border-white dark:text-white shadow-sm rounded-xs scheme-light dark:scheme-dark"
-            aria-label="Sort by"
-          >
-            <select-value />
-            <icon name="ph:caret-down-bold" size=".8em" class="ml-1" />
-          </select-trigger>
-          <select-portal>
-            <select-content
-              class="bg-white dark:bg-black rounded-xs border shadow-sm z-[100]"
-              :side-offset="5"
-            >
-              <select-viewport class="p-[5px]">
-                <select-item
-                  v-for="item of items"
-                  :key="item.value"
-                  :value="item.value"
-                  class="flex items-center pl-[20px] cursor-pointer hover:bg-gray-300 dark:hover:bg-gray-700"
-                  >
-                  <SelectItemIndicator class="absolute left-0 w-[25px] inline-flex items-center justify-center">
-                    <icon name="fa-solid:check" size=".8em" />
-                  </SelectItemIndicator>
-                  <select-item-text>{{ item.label }}</select-item-text>
-                </select-item>
-              </select-viewport>
-            </select-content>
-          </select-portal>
-        </select-root>
+            {{ item.label }}
+          </option>
+        </Select>
       </template>
     </ais-sort-by>
   </label>

--- a/client/components/Select.vue
+++ b/client/components/Select.vue
@@ -1,0 +1,32 @@
+<template>
+  <span
+    class="inline-block outline-1 rounded-xs outline-gray-400 focus-within:ring-black focus-within:ring-offset-4 focus-within:ring-2"
+  >
+    <select
+      v-bind="$attrs"
+      :class="['focus:ring-none focus:outline-none py-2 mx-4', props.class]"
+    >
+      <slot />
+    </select>
+  </span>
+</template>
+
+<script setup lang="ts">
+/**
+ * A <select> that appears to have internal padding so that the native <select> dropdown icon 'v' will be padded from
+ * the edge.
+ *
+ * This works by disabling the native <select> focus ring, and using 'focus-within' from a container with spacing.
+ *
+ * Usage of this component should wrap it in a <label> because the area outside the <select> isn't focusable, but the
+ * <label> will make it so.
+ */
+
+import type { VueStyleClass } from '~/utilities/vue'
+
+type Props = {
+  class?: VueStyleClass
+}
+
+const props = defineProps<Props>()
+</script>


### PR DESCRIPTION
## feat

* New component `<Select>` that's a native `<select>` which appears to have internal padding so that the native <select> dropdown icon `v` will be padded from the edge. This works by disabling the native <select> focus ring, and using 'focus-within' from a container with spacing. Usage of this component should wrap it in a <label> because the area outside the <select> isn't focusable, but the <label> will make it so.
* Using it on the search page

visual regression test failures are also on `main` so ignore those