### PR TITLE
feat: lessen search layout shift

### DIFF
--- a/client/pages/search.vue
+++ b/client/pages/search.vue
@@ -23,7 +23,6 @@
                   autofocus
                   placeholder="Find an RFC (number, subseries, title, author, etc.)"
                   :class-names="{
-                    'ais-SearchBox': 'grow',
                     'ais-SearchBox-form': 'w-full flex',
                     'ais-SearchBox-input':
                       'flex-1 bg-white text-black dark:bg-black dark:text-white dark:border-white dark:border pl-4 py-3 pr-2 h-12 rounded-l-xs',

--- a/client/pages/search.vue
+++ b/client/pages/search.vue
@@ -270,15 +270,6 @@ const routing = {
   }
 }
 
-type HandleStateChangeProps = {
-  uiState: unknown
-  setUiState: unknown
-}
-
-const handleStateChange = ({ uiState, setUiState }: HandleStateChangeProps) => {
-  console.log('handleStateChange', { uiState })
-}
-
 definePageMeta({
   layout: false
 })

--- a/client/pages/search.vue
+++ b/client/pages/search.vue
@@ -7,7 +7,6 @@
       :search-client="searchClient"
       :future="{ preserveSharedStateOnUnmount: true }"
       :routing="routing"
-      :on-state-change="handleStateChange"
     >
       <NuxtLayout name="default">
         <template #subheader>

--- a/client/pages/search.vue
+++ b/client/pages/search.vue
@@ -7,6 +7,7 @@
       :search-client="searchClient"
       :future="{ preserveSharedStateOnUnmount: true }"
       :routing="routing"
+      :on-state-change="handleStateChange"
     >
       <NuxtLayout name="default">
         <template #subheader>
@@ -18,29 +19,32 @@
               Search RFCs
             </Heading>
             <div class="flex flex-row items-center pt-4 pb-6">
-              <ais-search-box
-                autofocus
-                placeholder="Find an RFC (number, subseries, title, author, etc.)"
-                :class-names="{
-                  'ais-SearchBox': 'grow',
-                  'ais-SearchBox-form': 'w-full flex',
-                  'ais-SearchBox-input':
-                    'flex-1 bg-white text-black dark:bg-black dark:text-white dark:border-white dark:border pl-4 py-3 pr-2 rounded-l-xs',
-                  'ais-SearchBox-submit':
-                    'bg-blue-200 px-2 flex items-center rounded-r-xs',
-                  'ais-SearchBox-reset': 'hidden',
-                  'ais-SearchBox-loadingIndicator':
-                    'bg-yellow-400 px-2 flex items-center text-white'
-                }"
-                show-loading-indicator
-              >
-                <template #submit-icon>
-                  <Icon name="fluent:search-12-filled" size="2em" />
-                </template>
-                <template #loading-indicator>
-                  <Icon name="eos-icons:loading" size="2em" />
-                </template>
-              </ais-search-box>
+              <div class="w-2/3 h-12">
+                <ais-search-box
+                  autofocus
+                  placeholder="Find an RFC (number, subseries, title, author, etc.)"
+                  :class-names="{
+                    'ais-SearchBox': 'grow',
+                    'ais-SearchBox-form': 'w-full flex',
+                    'ais-SearchBox-input':
+                      'flex-1 bg-white text-black dark:bg-black dark:text-white dark:border-white dark:border pl-4 py-3 pr-2 h-12 rounded-l-xs',
+                    'ais-SearchBox-submit':
+                      'bg-blue-200 px-2 flex items-center rounded-r-xs',
+                    'ais-SearchBox-reset': 'hidden',
+                    'ais-SearchBox-loadingIndicator':
+                      'bg-yellow-400 px-2 flex items-center text-white'
+                  }"
+                  show-loading-indicator
+                >
+                  <template #submit-icon>
+                    <Icon name="fluent:search-12-filled" size="2em" />
+                  </template>
+                  <template #loading-indicator>
+                    <Icon name="eos-icons:loading" size="2em" />
+                    <div class="bg-red-500 w-5 h-5"></div>
+                  </template>
+                </ais-search-box>
+              </div>
               <div class="pl-5 grow">
                 <label class="text-base cursor-pointer flex items-center">
                   <input
@@ -55,7 +59,9 @@
           </div>
         </template>
 
-        <div class="container mx-auto flex flex-row items-start py-5">
+        <div
+          class="container mx-auto flex flex-row items-start py-5 lg:min-h-screen"
+        >
           <div class="hidden lg:w-1/3 lg:block">
             <SearchFilter />
           </div>
@@ -128,6 +134,8 @@ import type {
 } from '../utilities/typesense'
 import RFCCardTypeSenseItem from '~/components/RFCCardTypeSenseItem.vue'
 import { adaptSearchClient } from '~/utilities/search-client-middleware'
+import { useRfcEditorHead } from '~/utilities/head'
+import { searchPathBuilder } from '~/utilities/url'
 
 const route = useRoute()
 const searchStore = useSearchStore()
@@ -160,15 +168,20 @@ const INDEX_NAME = 'docs'
 const searchClient = adaptSearchClient(
   typesenseAdapter.searchClient as TypeSenseClient
 )
+
 const aisInstantSearchRef = useTemplateRef('aisInstantSearchRef')
 
 /**
  * Switch search preset if toggling search in RFC contents option
  */
-watch(() => searchStore.searchContents, newValue => {
-  typesenseAdapter.configuration.additionalSearchParameters.preset = newValue ? 'red-content' : 'red'
-  aisInstantSearchRef.value?.instantSearchInstance.helper.search()
-})
+watch(
+  () => searchStore.searchContents,
+  (newValue) => {
+    typesenseAdapter.configuration.additionalSearchParameters.preset =
+      newValue ? 'red-content' : 'red'
+    aisInstantSearchRef.value?.instantSearchInstance.helper.search()
+  }
+)
 
 /**
  * UI State
@@ -257,7 +270,23 @@ const routing = {
   }
 }
 
+type HandleStateChangeProps = {
+  uiState: unknown
+  setUiState: unknown
+}
+
+const handleStateChange = ({ uiState, setUiState }: HandleStateChangeProps) => {
+  console.log('handleStateChange', { uiState })
+}
+
 definePageMeta({
   layout: false
+})
+
+useRfcEditorHead({
+  title: 'Search',
+  canonicalUrl: searchPathBuilder({}),
+  description: 'Search RFCs by number, title, subseries, author, etc.',
+  contentType: 'website'
 })
 </script>


### PR DESCRIPTION
## feat:

*  lessen search layout shift (see [CLS](https://web.dev/articles/cls) for how it impacts search ranking)
* meta tags on search page (title etc.). The `canonical` url for this page is just `/search/` regardless of search value / search params etc.

Previously the search page looked like this during loading but now the layout shift is much less
![Screenshot_2025-06-19_09-48-35](https://github.com/user-attachments/assets/a6e34d2b-b9cf-491e-bb39-d14f29a5d2a5)

