### PR TITLE
feat: RFC info sidebar

### DIFF
--- a/client/components/RFCDocumentSidebar.vue
+++ b/client/components/RFCDocumentSidebar.vue
@@ -4,46 +4,42 @@
       <DialogTrigger />
       <DialogPortal>
         <DialogOverlay />
-        <DialogContent
-          :class="// needs overflow-y-scroll to force scrollbars, to ensure same page width as the main view
-          'absolute inset-0 z-50 bg-blue-900 text-white dark:bg-blue-950 dark:text-white overflow-y-scroll h-full'"
-        >
+        <DialogContent :class="// needs overflow-y-scroll to force scrollbars, to ensure same page width as the main view
+          'absolute inset-0 z-50 bg-blue-900 text-white dark:bg-blue-950 dark:text-white overflow-y-scroll h-full'">
           <DialogTitle />
           <DialogDescription>
-            <RFCMobileBanner
-              :rfc="props.rfc"
-              :rfc-bucket-html-doc="props.rfcBucketHtmlDoc"
-              :is-fixed="false"
-            >
-              <button
-                class="bg-white rounded-l text-black p-2 flex items-center"
-                aria-label="Close"
-                @click="isModalOpen = false"
-              >
+            <RFCMobileBanner :rfc="props.rfc" :rfc-bucket-html-doc="props.rfcBucketHtmlDoc" :is-fixed="false">
+              <button class="bg-white rounded-l text-black p-2 flex items-center" aria-label="Close"
+                @click="isModalOpen = false">
                 <GraphicsExpandSidebar class="inline-block mr-1 rotate-180" />
               </button>
             </RFCMobileBanner>
             <div class="px-2">
-              <RFCTabs
-                ref="mobileRFCTabs"
-                v-model:selected-tab="selectedTab"
-                :rfc="props.rfc"
-                :rfc-bucket-html-doc="props.rfcBucketHtmlDoc"
-              />
+              <RFCTabs ref="mobileRFCTabs" v-model:selected-tab="selectedTab" :rfc="props.rfc"
+                :rfc-bucket-html-doc="props.rfcBucketHtmlDoc" />
             </div>
           </DialogDescription>
           <DialogClose />
         </DialogContent>
       </DialogPortal>
     </DialogRoot>
-    <div class="sticky top-0 h-[100vh] overflow-y-scroll">
+    <TableOfContentsHighlight :toc="props.rfcBucketHtmlDoc.tableOfContents!" list-type="ordered"
+      wrapper-class="h-[calc(100vh-24px)] pb-2" list-class="mr-1" nested-list-class="pl-1"
+      :list-item-class="`block text-sm py-2 border-t-1 border-t-gray-300 dark:border-t-gray-500 no-underline hover:underline ${ANCHOR_TAILWIND_STYLE}`"
+      list-item-active-class="text-shadow-bold">
+      <Heading level="2" style-level="5" class="mb-1 text-gray-800 dark:text-gray-300">
+        In this section
+      </Heading>
+    </TableOfContentsHighlight>
+
+    <!-- <div class="sticky top-0 h-[100vh] overflow-y-scroll">
       <RFCTabs
         ref="desktopRFCTabs"
         v-model:selected-tab="selectedTab"
         :rfc="props.rfc"
         :rfc-bucket-html-doc="props.rfcBucketHtmlDoc"
       />
-    </div>
+    </div> -->
   </div>
 </template>
 
@@ -59,6 +55,7 @@ import {
   DialogTrigger
 } from 'reka-ui'
 import type { RfcBucketHtmlDocument, RfcCommon } from '~/utilities/rfc'
+import { ANCHOR_TAILWIND_STYLE } from '~/utilities/theme'
 
 type Props = {
   rfc: RfcCommon

--- a/client/utilities/scroll.ts
+++ b/client/utilities/scroll.ts
@@ -40,12 +40,13 @@ export const useTocActiveId = (ids: Ref<string[]>) => {
   }
 
   const updateElements = () => {
-    elements = Array.from(
-      document.querySelectorAll(ids.value.map((id) => `#${id}`).join(','))
-    )
-    if (elements.length !== ids.value.length) {
+    const uniqueIds = Array.from(new Set([...ids.value]))
+    const selector = uniqueIds.map((id) => `#${CSS.escape(id)}`).join(',')
+    elements = Array.from(document.querySelectorAll(selector))
+
+    if (elements.length !== uniqueIds.length) {
       throw Error(
-        `Some ids weren't found: ${JSON.stringify(ids.value.filter((id) => elements.some((element) => element.id === id)))}`
+        `Some ids weren't found (${elements.length} !== ${uniqueIds.length}) by selector ${selector}: ${JSON.stringify(uniqueIds.filter((id) => elements.some((element) => element.id === id)))}`
       )
     }
     elementTops = elements.map(


### PR DESCRIPTION
## feat

* updates TOC scraping to extract TOC from HTML. This will ensure TOC depth from XML is respected.
* Starts refactoring TOC sidebar used on markdown pages to handle both usecases

## fix

* fix scroll watcher to escape querySelectorAll DOM ids correctly

** screenshot **
![Screenshot_2025-07-04_16-07-14](https://github.com/user-attachments/assets/557e690a-800b-4713-9fcf-4eba6e6e4f79)
