### PR TITLE
fix: touch watcher

### DIFF
--- a/client/stores/hasTouch.ts
+++ b/client/stores/hasTouch.ts
@@ -8,25 +8,32 @@
  * side detection of capabilities
  */
 
-export type HasTouchValue = undefined | boolean
-
-export const isTouchDevice = (): boolean => {
-  if (typeof window === 'undefined') {
-    throw Error(
-      `isTouchDevice() should not be used serverside. We want cachable server responses that don't vary by device.`
-    )
-  }
-
-  // https://stackoverflow.com/questions/63076960/detecting-touch-devices-and-detecting-can-hover-with-javascript-in-2020
-  return !!window.matchMedia('(pointer: coarse)').matches
-}
+export type HasTouchValue = null | boolean
 
 export const useHasTouchStore = defineStore('hasTouch', () => {
-  const hasTouch = ref<HasTouchValue>(undefined)
+  const hasTouch = ref<HasTouchValue>(null)
 
-  onMounted(() => {
-    hasTouch.value = isTouchDevice()
-  })
+  const getMatchMedia = () => window.matchMedia('(pointer: coarse)')
+
+  const updateTouchMode = () => {
+    const getTouchMode = (): HasTouchValue => {
+      if (typeof window === 'undefined') {
+        return null
+      }
+      const hasTouchMatchMedia = getMatchMedia()
+      return Boolean(hasTouchMatchMedia.matches)
+    }
+    const newTouchMode = getTouchMode()
+    if (newTouchMode !== hasTouch.value) {
+      hasTouch.value = newTouchMode
+    }
+    console.log('new mode', hasTouch.value)
+  }
+
+  if (typeof window !== 'undefined') {
+    updateTouchMode()
+    getMatchMedia().addEventListener('change', updateTouchMode)
+  }
 
   return { hasTouch }
 })

--- a/client/stores/responsiveMode.ts
+++ b/client/stores/responsiveMode.ts
@@ -10,25 +10,29 @@ export type ResponsiveMode = null | 'Desktop' | 'Mobile'
  *
  * So this store is only clientside.
  */
-const getResponsiveMode = (): ResponsiveMode => {
-  if (typeof window === 'undefined') {
-    return null
-  }
-  // 1024px from default 'lg' breakpoint see https://tailwindcss.com/docs/responsive-design
-  const tailwindBreakpointLg = window.matchMedia('(min-width: 1024px)')
-  return tailwindBreakpointLg.matches ? 'Desktop' : 'Mobile'
-}
-
 export const useResponsiveModeStore = defineStore('responsiveMode', () => {
   const responsiveMode = ref<ResponsiveMode>(null)
 
-  if (typeof window !== 'undefined') {
-    addEventListener('resize', () => {
-      const newResponsiveMode = getResponsiveMode()
-      if (newResponsiveMode !== responsiveMode.value) {
-        responsiveMode.value = newResponsiveMode
+  const getMatchMedia = () => window.matchMedia('(min-width: 1024px)')
+
+  const updateResponsiveMode = () => {
+    const getResponsiveMode = (): ResponsiveMode => {
+      if (typeof window === 'undefined') {
+        return null
       }
-    })
+      // 1024px from default 'lg' breakpoint see https://tailwindcss.com/docs/responsive-design
+      const tailwindBreakpointLg = getMatchMedia()
+      return tailwindBreakpointLg.matches ? 'Desktop' : 'Mobile'
+    }
+    const newResponsiveMode = getResponsiveMode()
+    if (newResponsiveMode !== responsiveMode.value) {
+      responsiveMode.value = newResponsiveMode
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    updateResponsiveMode()
+    getMatchMedia().addEventListener('change', updateResponsiveMode)
   }
 
   return { responsiveMode }


### PR DESCRIPTION
## fix

* touch/responsive mode variations weren't being recalculated after page load but now they are. This works in dev mode when changing devices (ie adding and removing touch support after page load).