### PR TITLE
fix: homepage 'standards' card link

### DIFF
--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -5,30 +5,39 @@
         <IndexSubheader />
       </template>
       <div class="container mx-auto">
-        <div
-          class="flex flex-col-reverse lg:flex-row lg:items-center justify-between"
-        >
-          <Heading level="2" has-icon class="text-left mt-10 pl-5 md:pl-0">
+        <div class="flex flex-col-reverse lg:flex-row lg:items-center justify-between">
+          <Heading
+            level="2"
+            has-icon
+            class="text-left mt-10 pl-5 md:pl-0"
+          >
             Latest RFCs
           </Heading>
           <p class="hidden mt-8 lg:block text-base text-grey-800 pl-5">
             Looking for works in progress? Go to
-            <A :href="DATATRACKER_URL" class="text-blue-300 dark:text-blue-100">
+            <A
+              :href="DATATRACKER_URL"
+              class="text-blue-300 dark:text-blue-100"
+            >
               datatracker.ietf.org
             </A>
           </p>
         </div>
 
         <div v-if="searchStatus === 'error' && searchError">
-          <Alert variant="warning" heading="Unable to load latest RFCs">
+          <Alert
+            variant="warning"
+            heading="Unable to load latest RFCs"
+          >
             {{ searchError.statusMessage }}
           </Alert>
         </div>
 
-        <div
-          v-if="searchStatus === 'success' && topSearchResults?.length === 0"
-        >
-          <Alert variant="warning" heading="Unable to load latest RFCs">
+        <div v-if="searchStatus === 'success' && topSearchResults?.length === 0">
+          <Alert
+            variant="warning"
+            heading="Unable to load latest RFCs"
+          >
             Try again later (API error)
           </Alert>
         </div>
@@ -47,7 +56,11 @@
           />
         </div>
 
-        <Heading level="2" has-icon class="pl-5 mt-10 mb-5 md:p-0">
+        <Heading
+          level="2"
+          has-icon
+          class="pl-5 mt-10 mb-5 md:p-0"
+        >
           Learn about RFCs
         </Heading>
         <div class="grid grid-cols-1 mt-3 md:grid-cols-2 lg:grid-cols-4 gap-4">
@@ -57,11 +70,19 @@
           <MarkdownCard id="/about/rfc-editor/" />
         </div>
 
-        <Heading level="2" has-icon class="pl-5 mt-10 mb-5 md:p-0">
+        <Heading
+          level="2"
+          has-icon
+          class="pl-5 mt-10 mb-5 md:p-0"
+        >
           Browse RFCs
         </Heading>
         <div class="grid grid-cols-1 mt-3 md:grid-cols-2 lg:grid-cols-4 gap-4">
-          <Card :href="searchPathBuilder({})" heading-level="3" has-cover-link>
+          <Card
+            :href="searchPathBuilder({ status: ['Internet Standard'] })"
+            heading-level="3"
+            has-cover-link
+          >
             <template #headingTitle>Standards</template>
             <p class="text-base mt-2 text-blue-900 dark:text-white">
               Stable or mature protocols and services
@@ -82,11 +103,19 @@
           <MarkdownCard id="/series/rfc-download/" />
         </div>
 
-        <Heading level="2" has-icon class="pl-5 mt-10 mb-5 md:p-0">
+        <Heading
+          level="2"
+          has-icon
+          class="pl-5 mt-10 mb-5 md:p-0"
+        >
           Start Participating
         </Heading>
         <div class="grid grid-cols-1 mt-3 md:grid-cols-2 lg:grid-cols-4 gap-4">
-          <Card :href="IETF_URL" heading-level="3" has-cover-link>
+          <Card
+            :href="IETF_URL"
+            heading-level="3"
+            has-cover-link
+          >
             <template #headingTitle>Internet Engineering Task Force</template>
             <p class="text-base mt-2 text-blue-900 dark:text-white">
               Protocol standards, best current practices, experimental, and
@@ -94,14 +123,22 @@
             </p>
           </Card>
 
-          <Card :href="IRTF_URL" heading-level="3" has-cover-link>
+          <Card
+            :href="IRTF_URL"
+            heading-level="3"
+            has-cover-link
+          >
             <template #headingTitle>Internet Research Task Force</template>
             <p class="text-base mt-2 text-blue-900 dark:text-white">
               Research issues related to the Internet
             </p>
           </Card>
 
-          <Card :href="IAB_URL" heading-level="3" has-cover-link>
+          <Card
+            :href="IAB_URL"
+            heading-level="3"
+            has-cover-link
+          >
             <template #headingTitle>Internet Architecture Board</template>
             <p class="text-base mt-2 text-blue-900 dark:text-white">
               Long-range technical direction for Internet development
@@ -141,7 +178,7 @@ const {
 const topSearchResults = computed(() => {
   const allSearchResults = searchResponse.value?.results
   return Array.isArray(allSearchResults) ?
-      allSearchResults.slice(0, 3).map(rfcMetadataToRfcCommon)
+    allSearchResults.slice(0, 3).map(rfcMetadataToRfcCommon)
     : []
 })
 


### PR DESCRIPTION
## fix

* homepage link to search results for 'Standards' was just a default search link but now it preselects 'Internet Standards'