### PR TITLE
feat: plaintext rfc formatting and misc fixes

### DIFF
--- a/client/assets/css/rfc-plaintext.css
+++ b/client/assets/css/rfc-plaintext.css
@@ -145,7 +145,7 @@ pre {
     2119 | 72              | (MAGIC_SCALING_NUMBER ÷ 72)  × 1cqi | 27.02px
     
     Pretty close!
-    
+
     With information about each RFC's max line length AND `cqi` container width we can
     scale font-size smoothly from mobile to desktop, always looking right (arguably),
     always fitting unusual mobile phone widths, never leaving too much whitespace on
@@ -166,7 +166,7 @@ pre {
     that would leave a lot of whitespace to the right. We could reduce the entire
     container width per-RFC but that would be an unusual website design choice.
 
-    The MAGIC_NUMBER could have a few more decimal places.
+    The MAGIC_SCALING_NUMBER could have a few more decimal places.
 
     The first table's 'Optimal font-size' was done manually in the browser dev tools
     by changing the font-size until it was (1) subjectively visually pleasing, and

--- a/client/assets/css/rfc-plaintext.css
+++ b/client/assets/css/rfc-plaintext.css
@@ -134,15 +134,17 @@ pre {
 
     So the optimal font-size formula is something like:
 
-      (MAGIC_NUMBER ÷ var(--preformatted-max-line-length)) × 1cqi)
+      (MAGIC_SCALING_NUMBER ÷ var(--preformatted-max-line-length)) × 1cqi)
 
-    where MAGIC_NUMBER = 165 the results are:
+    where MAGIC_SCALING_NUMBER = 165 the results are:
   
-    RFC  | Max line length | Formula                                 | Actual font-size
-    -----------------------------------------------------------------------------------
-    2124 | 132             | (MAGIC_NUMBER ÷ 132) × 1cqi = 14.72px   | 14.73px
-    2440 | 73              | (MAGIC_NUMBER ÷ 73)  × 1cqi = 26.62px   | 26.65px
-    2119 | 72              | (MAGIC_NUMBER ÷ 72)  × 1cqi = 26.99px   | 27.02px
+    RFC  | Max line length | Formula                             | Resulting font-size
+    -------------------------------------------------------------------------------
+    2124 | 132             | (MAGIC_SCALING_NUMBER ÷ 132) × 1cqi | 14.73px
+    2440 | 73              | (MAGIC_SCALING_NUMBER ÷ 73)  × 1cqi | 26.65px
+    2119 | 72              | (MAGIC_SCALING_NUMBER ÷ 72)  × 1cqi | 27.02px
+    
+    Pretty close!
     
     With information about each RFC's max line length AND `cqi` container width we can
     scale font-size smoothly from mobile to desktop, always looking right (arguably),
@@ -172,9 +174,10 @@ pre {
     
     The 'Optimal font-size' in the first table is a bit of a misnomer because it's not
     exactly pushed hard up against the container's width. A bit of space was left
-    intentionally left empty so that different font rendering or browser substitute
-    fonts don't break the design. The exact amount of offset will likely be revealed
-    during testing / bug reports.
+    intentionally empty so that different font rendering (and to a lesser extent browser
+    substitute fonts) don't break the design. The exact amount of offset will likely be
+    revealed during testing / bug reports. If we get bug reports we should decrease the
+    font-size slightly by increasing the MAGIC_SCALING_NUMBER
 
     */
 

--- a/client/assets/css/rfc-plaintext.css
+++ b/client/assets/css/rfc-plaintext.css
@@ -7,106 +7,114 @@ https://github.com/ietf-tools/datatracker/blob/2bf633bf70c40b9cb6baf428901615a04
 */
 pre {
     white-space: pre-wrap;
-    font-size: 0.40rem;
-}
 
-@media only screen and (min-width: 300px) {
-    pre {
-        font-size: 0.42rem;
-    }
-}
+    /**
+    Changing font size for plaintext RFCs? Here are some notes from a previous dev. Please feel free
+    to update.
 
-@media only screen and (min-width: 350px) {
-    pre {
-        font-size: 0.47rem;
-    }
-}
+    THE PROBLEM
+    Plaintext RFCs have an optimal font-size (based on the max line length) to fit
+    their container's width, and the container width changes responsively from
+    mobile to desktop etc.
 
-@media only screen and (min-width: 375px) {
-    pre {
-        font-size: 0.53rem;
-    }
-}
+    The container width doesn't scale linearly with browser width (`vw`). Eg, when changing
+    from mobile to desktop the layout adds a sidebar which reduces the container width;
+    there's a maximum container width of 1186px for very wide browsers; the padding
+    varies at different resolutions, etc. Because of this we can't simply use `vw` units,
+    or a CSS `clamp()` with `vw` units etc.
 
-@media only screen and (min-width: 400px) {
-    pre {
-        font-size: 0.57rem;
-    }
-}
+    We could have conventional responsive CSS @media{} queries specifying a lot of
+    screen resolutions and appropriate font-sizes to optimise font-size, but even a
+    basic implementation (see:
+    https://github.com/ietf-tools/red/pull/111/commits/1883affc3247b1641e63c3d5d2e761631c10bbfa#diff-eb730e8ef057ed3d5d223fdc888551e6d7c7c2152158ec98bdc222578f52b383R10
+    ) has 13 @media + font-size declarations, and it really works poorly. There are
+    sudden 'jumps' in font-size at responsive breakpoints and the adjacent whitespace,
+    to the right of the content, jumps too.
 
-@media only screen and (min-width: 500px) {
-    pre {
-        font-size: 0.7rem;
-    }
-}
+    Another complexity is that some RFCs are wider than 80 chars:
+    https://notes.ietf.org/VE2EoxbfRCm6X7W6NvghAA?view
 
-@media only screen and (min-width: 600px) {
-    pre {
-        font-size: 0.83rem;
-    }
-}
+    In summary:
+    * The widest plaintext RFC has a line length of 137 chars.
+    * Most RFcs are between 70-80 chars, usually 72-73.
 
-@media only screen and (min-width: 700px) {
-    pre {
-        font-size: 0.9rem;
-    }
-}
+    The optimal font-size for these would be approximately:
 
-@media only screen and (min-width: 770px) {
-    pre {
-        font-size: 1.05rem;
-    }
-}
+    RFC  | Max line length | Container width | Optimal font-size
+    -----------------------------------------------------------
+    2124 | 132             | 1178px          | 14.7px
+    2440 | 73              | 1178px          | 26.9px
+    2119 | 72              | 1178px          | 27px
 
-@media only screen and (min-width: 800px) {
-    pre {
-        font-size: 1.08rem;
-    }
-}
+    Using CSS container length units like `cqi` we can set font-size relative to the
+    container size. The `cqi` unit is 1% of the container which in this case would
+    be 11.78px
 
-@media only screen and (min-width: 1000px) {
-    pre {
-        font-size: 0.99rem;
-    }
-}
+    We precalculate each RFCs max line width chars and make it available in CSS as
+    var(--preformatted-max-line-length).
 
-@media only screen and (min-width: 1100px) {
-    pre {
-        font-size: 0.98rem;
-    }
-}
+    So the optimal font-size formula is something like:
 
-@media only screen and (min-width: 1200px) {
-    pre {
-        font-size: 0.98rem;
-    }
-}
+      (MAGIC_NUMBER ÷ var(--preformatted-max-line-length)) × 1cqi)
 
-@media only screen and (min-width: 1280px) {
-    pre {
-        font-size: 1.33rem;
-    }
-}
+    where MAGIC_NUMBER = 165 the results are:
+  
+    RFC  | Max line length | Formula                                 | Actual font-size
+    -----------------------------------------------------------------------------------
+    2124 | 132             | (MAGIC_NUMBER ÷ 132) × 1cqi = 14.72px   | 14.73px
+    2440 | 73              | (MAGIC_NUMBER ÷ 73)  × 1cqi = 26.62px   | 26.65px
+    2119 | 72              | (MAGIC_NUMBER ÷ 72)  × 1cqi = 26.99px   | 27.02px
+    
+    With information about each RFC's max line length AND `cqi` container width we can
+    scale font-size smoothly from mobile to desktop, always looking right (arguably),
+    always fitting unusual mobile phone widths, never leaving too much whitespace on
+    the right, etc. Nice.
 
-@media only screen and (min-width: 1538px) {
-    pre {
-        font-size: 1.65rem;
-    }
-}
+    Further considerations:
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-    white-space: pre;
-    display: inline;
+    Mobile:
+    Arguably the font-size is too small on mobile.
+    The font-size is small on mobile and this is intentional.
+    Currently mobile users are expected to 'pinch zoom' to read the text (or increase
+    page zoom using accessibility tools).
+    We could increase the font-size but then a line of text would still be offscreen.
+    We could increase the font-size and also force wrap the text but that would break
+    ASCII art and other things that need to align across lines.
+
+    Arguably the font-size is too large on desktop. Perhaps it could be clamped but
+    that would leave a lot of whitespace to the right. We could reduce the entire
+    container width per-RFC but that would be an unusual website design choice.
+
+    The MAGIC_NUMBER could have a few more decimal places.
+
+    The first table's 'Optimal font-size' was done manually in the browser dev tools
+    by changing the font-size until it was (1) subjectively visually pleasing, and
+    (2) before line wrapping occured.
+    
+    The 'Optimal font-size' in the first table is a bit of a misnomer because it's not
+    exactly pushed hard up against the container's width. A bit of space was left
+    intentionally left empty so that different font rendering or browser substitute
+    fonts don't break the design. The exact amount of offset will likely be revealed
+    during testing / bug reports.
+
+    */
+
+    /* Default font size for browsers that don't support cqi container units */
+    font-size: 16px;
+    --magic-scaling-number: 165;
+    font-size: calc((var(--magic-scaling-number) / var(--preformatted-max-line-length)) * 1cqi);
 }
 
 @media only screen {
     .newpage {    
-        margin-top: -1.25em;
+        /** upstream CSS was:
+
+              margin-top: -1.25em; 
+
+            which causes pages to overlap which doesn't matter in most cases because
+            most RFCs have trailing/leading whitespace between pages, but RFC708 (and
+            perhaps others?) don't, so we'll disable it for now.
+        **/
     }
 }
 

--- a/client/assets/css/rfc-plaintext.css
+++ b/client/assets/css/rfc-plaintext.css
@@ -32,11 +32,90 @@ pre {
     to the right of the content, jumps too.
 
     Another complexity is that some RFCs are wider than 80 chars:
-    https://notes.ietf.org/VE2EoxbfRCm6X7W6NvghAA?view
+        (note that the given command may have false positives, so verify for yourself)
+
+        $ find . -name "rfc[0-9]*.txt" -print0 | xargs -0 awk 'length > 80 {print FILENAME ": Line " NR ": " $0}'
+
+        ./rfc9676.txt: Line 42183:    ISO plus Hebrew format as: 1999-09-02|כ״א-בֶּאֱלוּל-תשנ״ט which is to
+        ./rfc9110.txt: Line 57476:    Дилян Палаузов (Dilyan Palauzov), Eric Anderson, Eric Rescorla, Éric
+        ./rfc2124.txt: Line 475794:    |                                                               |                                                               |
+        ./rfc2124.txt: Line 475796:    |                                                               |                                                               |
+        ./rfc589.txt: Line 2742031: A.  INITIAL CONNECTION, SIGNON, AND SIGNOFF
+        ./rfc589.txt: Line 2742087: B.  REMOTE SITE OR NETWORK FAILURES
+        ./rfc1856.txt: Line 3497396:     >SELECT OARnet rtr1 eth0 InBytes 15min 1993-02-01 00:00:00 1993-03-01 23:59:59
+        ./rfc1060.txt: Line 4259652:    09-00-2B-01-00-01       8038    DEC LanBridge Hello packets (All local bridges)
+        ./rfc1060.txt: Line 4259702:    CF-00-00-00-00-00       9000    Ethernet Configuration Test protocol (Loopback)
+        ./rfc1277.txt: Line 4782185: |Value__|T|elex_|007_28722__|__02___|___2_____|_2_|____049050_000005111600____|__
+        ./rfc9438.txt: Line 5638664:                                 ┌────────────────┐
+        ./rfc9438.txt: Line 5638667:                          K =  ╲ │────────────────
+        ./rfc9438.txt: Line 5638727:                                       ┌───────────────┐
+        ./rfc9438.txt: Line 5638729:                    AVG_AIMD(α, β) = ╲ │───────────────
+        ./rfc9438.txt: Line 5638775:                    W    = W    + α      * ──────────────
+        ./rfc9438.txt: Line 5638920:        ⎪cwnd * ────────── if  cwnd < W     and fast convergence enabled,
+        ./rfc9438.txt: Line 5639071:                                ┌────────────────┐   4 ┌────┐
+        ./rfc9438.txt: Line 5639074:                AVG_W      = ╲  │────────────────  * ────────
+        ./rfc9438.txt: Line 5639086:                     AVG_W      = ╲ │───────  * ────────
+        ./rfc9438.txt: Line 5639620:                               ┌────────────────────┐
+        ./rfc9438.txt: Line 5639623:                        K =  ╲ │────────────────────
+        ./rfc9438.txt: Line 5639673:                              ┌──────────────────────┐
+        ./rfc9438.txt: Line 5639676:                       K = ╲  │──────────────── * ───
+        ./rfc9438.txt: Line 5639685:                             1       ┌───────────────────────┐
+        ./rfc9438.txt: Line 5639688:               AVG_W      = ─── = ╲  │──────────────── * ────
+        ./rfc9389.txt: Line 5666803:               ⎛  L   ⎞    ╲    ⎢⎛B⎞     ╲     ⎛⎛B⎞ ⎛      B      ⎞⎞⎥
+        ./rfc9389.txt: Line 5666804:        C(N) = ⎜      ⎟    ╱    ⎢⎜ ⎟     ╱     ⎜⎜ ⎟ ⎜             ⎟⎟⎥
+        ./rfc9389.txt: Line 5666805:               ⎝10 - N⎠    ——   ⎢⎝i⎠     ——    ⎝⎝j⎠ ⎝min(2, N-i-j)⎠⎠⎥
+        ./rfc663.txt: Line 5998469: control message called _ost_Message_from_Receiver (LMR) which  is
+        ./rfc663.txt: Line 5998498: Lost_Message_from_Sender  (LMS)  control  message  to  R  on  the
+        ./rfc663.txt: Line 5998524: to continue by transmitting  a  _oss_of_Message_Acceptable  (LMA)
+        ./rfc663.txt: Line 5998622: of these, called _equest _tatus from _ender (RSS), can be used by
+        ./rfc663.txt: Line 5998625: number  and  MSN for a transmission path by sending a _tatus from
+        ./rfc663.txt: Line 5998626: _eceiver (SFR) control message over the control channel.  An  SFR
+        ./rfc662.txt: Line 6404769: significantly larger messages<s1>s This will result in fewer RFNMs and delays and
+        ./rfc684.txt: Line 6713017: Limitations of Procedure Calling Across Machines___________ __ _________ _______ ______ ________
+        ./rfc731.txt: Line 981845:      _he__etwork__irtual__ata__ntry__erminal(NVDET)
+        ./rfc731.txt: Line 981908:      _acility__unctions  (for detailed semantics see Section 5.)
+        ./rfc731.txt: Line 982258:      _ransmit__unctions  (For detailed semantics see Section 5.)
+        ./rfc731.txt: Line 982822:      _hen__ent_  A Server Telnet  implementation  using  the  DET
+        ./rfc731.txt: Line 982844:      _ction__hen__ecieved_  There are two possible  actions  that
+        ./rfc9385.txt: Line 1137988:             :         'Удостоверяющий центр "КриптоПро УЦ"'
+        ./rfc9385.txt: Line 1137990:             :         'Сертификат соответствия № СФ/000-0000 от 00.00.'
+        ./rfc9385.txt: Line 1137993:             :         'Сертификат соответствия № СФ/000-0000 от 00.00.'
+        ./rfc1246.txt: Line 1289165: __________________________________________________________________________________
+        ./rfc708.txt: Line 1802046: This new procedure effectively adds to the Model the notion of "creation," and enables the environment to offer the following primitives
+        ./rfc708.txt: Line 1802310: Although a single procedure can be considered a resource, it is more practical and convenient to conceive of larger, composite resources
+        ./rfc1045.txt: Line 1944887:                 NotifyRemoteVmtpClient(client,ctrl,recSeq,transact,delivery,code->()
+        ./rfc643.txt: Line 2748525: Op-Code 4 - DEPOSIT (Process, Address, Count, Byte String)_______ _ _ _______ _________ ________ ______ ____ _______
+        ./rfc643.txt: Line 2748558: Op-Code 6 - EXAMINE (Process, Address, Count)_______ _ _ _______ _________ ________ ______
+        ./rfc643.txt: Line 2748572: Op-Code 7 - DEPOSIT STATE VECTOR (Process, Index, Byte Count,_______ _ _ _______ _____ ______ _________ ______ ____ ______
+        ./rfc643.txt: Line 2748587: Op-Code 10 - BREAK (Process, Address, Proceed Count)_______ __ _ _____ _________ ________ _______ ______
+        ./rfc643.txt: Line 2748697:                  Asynchronous Stop Replies                 ____________ ____ _______
+        ./rfc643.txt: Line 2748712: Op-Code 100 - TRAP (Process, Reason, 0, STATE VECTOR)_______ ___ _ ____ _________ _______ __ _____ _______
+        ./rfc643.txt: Line 2748718: Op-Code 101 - HALT (Process, 0,0, STATE VECTOR)_______ ___ _ ____ _________ ____ _____ _______
+        ./rfc643.txt: Line 2748723: Op-Code 102 - BPT (Process, 0, 0, STATE VECTOR)_______ ___ _ ___ _________ __ __ _____ _______
+        ./rfc643.txt: Line 2748728: Op-Code 103 - TTRAP (Process, 0, 0, STATE VECTOR)_______ ___ _ _____ _________ __ __ _____ _______
+        ./rfc1142.txt: Line 4150959: that is the size of the option header. Where possible the PDU should be padded to
+        ./rfc1142.txt: Line 4157134: a)Only the first three items are required for all implementations; others may be
+        ./rfc2885.txt: Line 4253482:                     Table                        Identifier Transport)                              4 OCTETS
+        ./rfc1341.txt: Line 4299196:                   F.3  Registration of New Access-type Values for Message/external-body69
+        ./rfc752.txt: Line 4427152: HOST SRI-C3PO,          3/51,USER,ELF,PDP11,[PKT40,C3PO] ; What about Darth Vader?
+        ./rfc752.txt: Line 4427154: HOST SRI-KL,            1/2,SERVER,TOPS-20,PDP10,[SRI,NIC,KL,AIC,SRI-AI,SRI-TWENEX]
+        ./rfc752.txt: Line 4427160: HOST SU-AI,             [0/11,DIAL 4154941659],SERVER,WAITS,PDP10,[SAIL,SU-WAITS]
+        ./rfc1147.txt: Line 4963730:                     to achieve low response time," IFIP WG6.1/6.4:
+        ./rfc1147.txt: Line 4963731:                     Protocols for High-Speed Networks, May 1989,
+        ./rfc1147.txt: Line 4963761:                     of 13:th Conf. on Local Computer Networks, Min-
+        ./rfc1147.txt: Line 4966178:           networking With TCP/IP, by Douglas Comer, is an informative
+        ./rfc1147.txt: Line 4966180:           architecture.  The UNIX System Administration Handbook, by
+        ./rfc1379.txt: Line 5103360:         ___TCP_A_____                                ___TCP_B_____
+        ./rfc1344.txt: Line 5164548:                  XW5YKxqPyKRygxv2dr4czwlMCZrQLFTYHBJ2hlyQYFiaz+i0WWBou7fOq1x8vXWfU
+        ./rfc1344.txt: Line 5164549:                  qU1fJ2qEhYaHGjhZQmJ2QT1xBW1ak1xUdV0/VjtsbpUEDaEJCQOIpqeoNV+LXo5W
+        ./rfc1344.txt: Line 5164589:                  XW5YKxqPyKRygxv2dr4czwlMCZrQLFTYHBJ2hlyQYFiaz+i0WWBou7fOq1x8vXWfU
+        ./rfc1344.txt: Line 5164590:                  qU1fJ2qEhYaHGjhZQmJ2QT1xBW1ak1xUdV0/VjtsbpUEDaEJCQOIpqeoNV+LXo5W
+        ./rfc9446.txt: Line 5364225:    In the 9th century, Abū Yūsuf Yaʻqūb ibn ʼIsḥāq aṣ-Ṣabbāḥ al-Kindī
+        ./rfc635.txt: Line 5707218: ^^^This interval is a function of line speed and load and may be as low as 128 ms.
 
     In summary:
     * The widest plaintext RFC has a line length of 137 chars.
-    * Most RFcs are between 70-80 chars, usually 72-73.
+    * Most RFCs are between 70-80 chars, usually 72-73.
 
     The optimal font-size for these would be approximately:
 

--- a/client/assets/css/rfc-plaintext.css
+++ b/client/assets/css/rfc-plaintext.css
@@ -13,9 +13,9 @@ pre {
     to update.
 
     THE PROBLEM
-    Plaintext RFCs have an optimal font-size (based on the max line length) to fit
-    their container's width, and the container width changes responsively from
-    mobile to desktop etc.
+    Plaintext RFCs are fixed-width, which means they have an optimal font-size (based on their
+    max line length) to fit their container's width, and the container width changes responsively
+    from mobile to desktop etc.
 
     The container width doesn't scale linearly with browser width (`vw`). Eg, when changing
     from mobile to desktop the layout adds a sidebar which reduces the container width;

--- a/client/assets/css/rfc-plaintext.css
+++ b/client/assets/css/rfc-plaintext.css
@@ -6,8 +6,92 @@ https://github.com/ietf-tools/datatracker/blob/2bf633bf70c40b9cb6baf428901615a04
 
 */
 pre {
-    width: 80ch;
     white-space: pre-wrap;
+    font-size: 0.40rem;
+}
+
+@media only screen and (min-width: 300px) {
+    pre {
+        font-size: 0.42rem;
+    }
+}
+
+@media only screen and (min-width: 350px) {
+    pre {
+        font-size: 0.47rem;
+    }
+}
+
+@media only screen and (min-width: 375px) {
+    pre {
+        font-size: 0.53rem;
+    }
+}
+
+@media only screen and (min-width: 400px) {
+    pre {
+        font-size: 0.57rem;
+    }
+}
+
+@media only screen and (min-width: 500px) {
+    pre {
+        font-size: 0.7rem;
+    }
+}
+
+@media only screen and (min-width: 600px) {
+    pre {
+        font-size: 0.83rem;
+    }
+}
+
+@media only screen and (min-width: 700px) {
+    pre {
+        font-size: 0.9rem;
+    }
+}
+
+@media only screen and (min-width: 770px) {
+    pre {
+        font-size: 1.05rem;
+    }
+}
+
+@media only screen and (min-width: 800px) {
+    pre {
+        font-size: 1.08rem;
+    }
+}
+
+@media only screen and (min-width: 1000px) {
+    pre {
+        font-size: 0.99rem;
+    }
+}
+
+@media only screen and (min-width: 1100px) {
+    pre {
+        font-size: 0.98rem;
+    }
+}
+
+@media only screen and (min-width: 1200px) {
+    pre {
+        font-size: 0.98rem;
+    }
+}
+
+@media only screen and (min-width: 1280px) {
+    pre {
+        font-size: 1.33rem;
+    }
+}
+
+@media only screen and (min-width: 1538px) {
+    pre {
+        font-size: 1.65rem;
+    }
 }
 
 h1,

--- a/client/assets/css/upstream-xml2rfc.css
+++ b/client/assets/css/upstream-xml2rfc.css
@@ -21,13 +21,13 @@ https://github.com/ietf-tools/xml2rfc/blob/main/xml2rfc/data/xml2rfc.css
 */
 
 /* fonts */
-@import url('https://fonts.googleapis.com/css?family=Noto+Sans'); /* Sans-serif */
-@import url('https://fonts.googleapis.com/css?family=Noto+Serif'); /* Serif (print) */
+/* @import url('https://fonts.googleapis.com/css?family=Noto+Sans'); Sans-serif */
+/* @import url('https://fonts.googleapis.com/css?family=Noto+Serif');  Serif (print) */
 @import url('https://fonts.googleapis.com/css?family=Roboto+Mono'); /* Monospace */
 
 :root {
-  --font-sans: 'Noto Sans', Arial, Helvetica, sans-serif;
-  --font-serif: 'Noto Serif', 'Times', 'Times New Roman', serif;
+  /* --font-sans: 'Noto Sans', Arial, Helvetica, sans-serif;
+  --font-serif: 'Noto Serif', 'Times', 'Times New Roman', serif; */
   --font-mono: 'Roboto Mono', Courier, 'Courier New', monospace;
 }
 
@@ -39,19 +39,6 @@ https://github.com/ietf-tools/xml2rfc/blob/main/xml2rfc/data/xml2rfc.css
   zoom: 1.0;
 }
 /* general and mobile first */
-html {
-}
-body {
-  max-width: 90%;
-  margin: 1.5em auto;
-  color: #222;
-  background-color: #fff;
-  font-size: 14px;
-  font-family: var(--font-sans);
-  line-height: 1.6;
-  scroll-behavior: smooth;
-  overflow-wrap: break-word;
-}
 .ears {
   display: none;
 }

--- a/client/components/BodyLayout/Document.vue
+++ b/client/components/BodyLayout/Document.vue
@@ -1,8 +1,6 @@
 <template>
-  <div
-    class="w-full container m-auto flex flex-row-reverse justify-between lg:gap-5"
-  >
-    <div :class="['flex flex-1 p-3 hidden lg:block', props.sidebarClass]">
+  <div class="w-full container m-auto flex flex-row-reverse justify-between lg:gap-5">
+    <div :class="['flex p-3 hidden w-[330px] lg:block', props.sidebarClass]">
       <slot name="sidebar" />
     </div>
     <div class="flex-auto">

--- a/client/components/Heading.vue
+++ b/client/components/Heading.vue
@@ -4,8 +4,12 @@
     :id="
       // we always make an id. hasInternalLink only affects whether to show a '#' link
       props.id ?? getAnchorId($slots.default)
-    "
-    :class="[headingStyles[`h${styleLevel || level}`], props.class, 'group']"
+      "
+    :class="[
+      headingStyles[`h${styleLevel || level}`],
+      props.class,
+      'group'
+    ]"
   >
     <GraphicsIETFMotif
       v-if="hasIcon"
@@ -17,16 +21,15 @@
     <slot />
     <a
       v-if="hasInternalLink"
-      :href="
-        hasInternalLink ?
-          `#${props.id ?? getAnchorId($slots.default)}`
+      :href="hasInternalLink ?
+        `#${props.id ?? getAnchorId($slots.default)}`
         : undefined
-      "
-      class="ml-2 opacity-50 no-underline group-hover:opacity-100 font-normal"
+        "
+      class="ml-1 opacity-0 transition-opacity no-underline group-hover:opacity-100 font-normal"
       title="Link to this heading"
       @click="hashClickHandler(`#${getAnchorId($slots.default)}`)"
     >
-      #
+      &para;
     </a>
   </component>
 </template>

--- a/client/components/RFCDocumentBody.vue
+++ b/client/components/RFCDocumentBody.vue
@@ -155,6 +155,10 @@ const rfcHtmlContainer = useTemplateRef('rfc-html-container')
 
 const enrichedDocument = ref<VNode | undefined>()
 
+const maxPreformattedLineLength = ref<number>(props.rfcBucketHtmlDoc.maxPreformattedLineLength ?? 80)
+
+
+
 onMounted(async () => {
   if (
     // if we've already computed it,
@@ -229,6 +233,12 @@ const enrichRfcDocument = async (nodes: Node[]): Promise<VNode> => {
 }
 
 .rfc-content-type-plaintext {
+  /** container used to scale `font-size` with units like `cqi`
+      https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries
+  */
+  container-type: inline-size;
+  --preformatted-max-line-length: v-bind(props.rfcBucketHtmlDoc.maxPreformattedLineLength);
+
   /* Using postcss-nested-import scope these imported styles */
   @nested-import "../assets/css/rfc-plaintext.css"
 }

--- a/client/components/RFCDocumentBody.vue
+++ b/client/components/RFCDocumentBody.vue
@@ -155,10 +155,6 @@ const rfcHtmlContainer = useTemplateRef('rfc-html-container')
 
 const enrichedDocument = ref<VNode | undefined>()
 
-const maxPreformattedLineLength = ref<number>(props.rfcBucketHtmlDoc.maxPreformattedLineLength ?? 80)
-
-
-
 onMounted(async () => {
   if (
     // if we've already computed it,

--- a/client/components/RFCDocumentBody.vue
+++ b/client/components/RFCDocumentBody.vue
@@ -18,14 +18,14 @@
 
   <Heading
     level="1"
-    class="mb-2 px-1 xs:px-0 print:px-0"
+    class="mb-2 pl-2 xs:px-0 print:px-0"
   >
     <component :is="formatTitleAsVNode(`${rfcId.type}${rfcId.number}`)" />
   </Heading>
 
   <Heading
     level="2"
-    class="mb-2 px-1 xs:px-0 print:px-0"
+    class="mb-2 pl-2 xs:px-0 print:px-0"
   >
     {{ rfc.title }}
   </Heading>
@@ -35,7 +35,7 @@
     :is-fixed="true"
   />
 
-  <div class="flex flex-row justify-between items-center flex-wrap">
+  <div class="flex ml-2 flex-row justify-between items-center flex-wrap">
     <div class="flex align-middle">
       <Tag
         :text="rfcId.type === RFC_TYPE_RFC ?
@@ -70,19 +70,6 @@
         </PopoverPortal>
       </PopoverRoot>
     </div>
-
-    <!-- <div v-if="props.rfc">
-      <button
-        type="button"
-        class="text-base underline text-blue-300 dark:text-blue-100 p-2"
-        @click="gotoErrata"
-      >
-        {{ props.rfc.errata }}
-
-        <template v-if="props.errata.length === 1">erratum</template>
-<template v-else>errata</template>
-</button>
-</div> -->
   </div>
 
   <Alert
@@ -107,15 +94,8 @@
     </div>
   </Alert>
 
-  <p
-    v-if="props.rfc.abstract"
-    class="px-1 xs:px-0 mb-2 text-base lg:text-xl print:px-0 text-pretty"
-  >
-    {{ props.rfc.abstract }}
-  </p>
-
   <div
-    :class="`rfc-content rfc-content-type-${props.rfcBucketHtmlDoc.documentHtmlType} mt-10 text-[9px] sm:text-base lg:text-base`"
+    :class="`rfc-content rfc-content-type-${props.rfcBucketHtmlDoc.documentHtmlType} mt-10 pl-2 text-[9px] sm:text-base lg:text-base`"
   >
     <div
       v-if="!enrichedDocument"

--- a/client/utilities/red-rfc-html-extractor-shared/index.ts
+++ b/client/utilities/red-rfc-html-extractor-shared/index.ts
@@ -12,12 +12,14 @@ import { assertNever } from '../typescript'
 import {
   getPlaintextRfcDocument,
   parsePlaintextBody,
-  parsePlaintextHead
+  parsePlaintextHead,
+  getPlaintextMaxLineLength
 } from './plaintext'
 import {
   getXml2RfcRfcDocument,
   parseXml2RfcBody,
-  parseXml2RfcHead
+  parseXml2RfcHead,
+  getXml2RfcMaxLineLength
 } from './xml2rfc'
 
 export const fetchSourceRfcHtml = async (
@@ -53,6 +55,8 @@ export const rfcBucketHtmlToRfcDocument = async (
 
   const documentHtmlType = sniffRfcBucketHtmlType(dom)
 
+  let maxPreformattedLineLength = 80
+
   let rfcDocument: Node[] = []
 
   switch (documentHtmlType) {
@@ -60,11 +64,13 @@ export const rfcBucketHtmlToRfcDocument = async (
       parsePlaintextHead(dom.head, rfcAndToc)
       parsePlaintextBody(dom.body, rfcAndToc)
       rfcDocument = getPlaintextRfcDocument(dom)
+      maxPreformattedLineLength = getPlaintextMaxLineLength(dom)
       break
     case 'xml2rfc':
       parseXml2RfcHead(dom.head, rfcAndToc)
       parseXml2RfcBody(dom.body, rfcAndToc)
       rfcDocument = getXml2RfcRfcDocument(dom)
+      maxPreformattedLineLength = getXml2RfcMaxLineLength(dom)
       break
     default:
       assertNever(documentHtmlType)
@@ -87,7 +93,8 @@ export const rfcBucketHtmlToRfcDocument = async (
     rfc: rfcAndToc.rfc,
     tableOfContents: rfcAndToc.tableOfContents,
     documentHtmlType,
-    documentHtml
+    documentHtml,
+    maxPreformattedLineLength
   }
 }
 

--- a/client/utilities/red-rfc-html-extractor-shared/plaintext.ts
+++ b/client/utilities/red-rfc-html-extractor-shared/plaintext.ts
@@ -245,3 +245,27 @@ export const getPlaintextRfcDocument = (dom: Document): Node[] => {
     return true
   })
 }
+
+export const getPlaintextMaxLineLength = (dom: Document): number => {
+  const DEFAULT_MAX_LINE_LENGTH = 50
+
+  const pres = Array.from(dom.body.querySelectorAll<HTMLElement>('pre'))
+  return pres.reduce((prevMaxLineLength, pre) => {
+    const maxLineLengthContenders = getInnerText(pre)
+      .split('\n')
+      .map((text) => ({
+        text,
+        length: text.length
+      }))
+    const biggerLines = maxLineLengthContenders.filter(
+      (line) => line.length > prevMaxLineLength
+    )
+    if (biggerLines.length) {
+      console.log('bigger', biggerLines)
+    }
+    return Math.max(
+      prevMaxLineLength,
+      ...maxLineLengthContenders.map((line) => line.length)
+    )
+  }, DEFAULT_MAX_LINE_LENGTH)
+}

--- a/client/utilities/red-rfc-html-extractor-shared/xml2rfc.ts
+++ b/client/utilities/red-rfc-html-extractor-shared/xml2rfc.ts
@@ -224,11 +224,12 @@ export const getXml2RfcRfcDocument = (dom: Document): Node[] => {
       }
       const idsToRemove = [
         'toc',
-        'external-metadata',
-        'internal-metadata',
         'rfcnum',
         'title',
-        'section-abstract'
+        'external-metadata',
+        'internal-metadata'
+
+        // 'section-abstract'
         // 'status-of-memo',
         // 'copyright'
       ]

--- a/client/utilities/red-rfc-html-extractor-shared/xml2rfc.ts
+++ b/client/utilities/red-rfc-html-extractor-shared/xml2rfc.ts
@@ -240,3 +240,28 @@ export const getXml2RfcRfcDocument = (dom: Document): Node[] => {
     return true
   })
 }
+
+/**
+ * Unlike plaintext RFCs these HTML RFCs aren't entirely <pre>formatted text
+ * but they can include preformatted sections (eg ASCII art) that should be
+ * sized, so we still calculate the max line length of <pre>s within.
+ */
+export const getXml2RfcMaxLineLength = (dom: Document): number => {
+  /**
+   * Unlike plaintext RFCs we can't assume <pre> sections within
+   * HTML are 80 chars by default. These <pre> sections might be just
+   * ASCII art without any particular width conventions, so we'll
+   * start off with a smaller number than 80.
+   */
+  const DEFAULT_MAX_LINE_LENGTH = 40
+
+  const pres = Array.from(dom.body.querySelectorAll<HTMLElement>('pre'))
+  return pres.reduce((maxLineLength, pre) => {
+    return Math.max(
+      maxLineLength,
+      ...getInnerText(pre)
+        .split('\n')
+        .map((line) => line.length)
+    )
+  }, DEFAULT_MAX_LINE_LENGTH)
+}

--- a/client/utilities/rfc.ts
+++ b/client/utilities/rfc.ts
@@ -213,4 +213,5 @@ export type RfcBucketHtmlDocument = {
   tableOfContents?: RfcEditorToc
   documentHtml: string
   documentHtmlType: 'plaintext' | 'xml2rfc'
+  maxPreformattedLineLength: number
 }


### PR DESCRIPTION
## feat

* `#` changed to pilcrow &para; in markdown pages, and the character isn't visible by default.
* plaintext RFC font size fixes (responsive). See docstring in `rfc-plaintext.css` for details.
* xml2rfc font family changes
* RFC content is indented from the side (previously was too close to the screen size)
* use the RFC HTML abstract rather than the one from Datatracker

### screenshots

**mobile**
<img width="401" height="1099" alt="Screenshot_2025-07-24_20-40-51" src="https://github.com/user-attachments/assets/f84c2fef-caeb-491d-a4c1-a4d4d163b57b" />

**tablet**
<img width="1021" height="1088" alt="Screenshot_2025-07-24_20-39-21" src="https://github.com/user-attachments/assets/0c85edf5-6f3c-447c-8c64-0c8762c5c4e5" />

**desktop**
<img width="2387" height="1216" alt="Screenshot_2025-07-24_20-37-46" src="https://github.com/user-attachments/assets/03a24548-a003-4259-aa48-e1cdb16b5c8b" />

