### PR TITLE
feat: plaintext max line length with anchor suffixes

### DIFF
--- a/client/assets/css/rfc-plaintext.css
+++ b/client/assets/css/rfc-plaintext.css
@@ -164,10 +164,6 @@ pre {
     We could increase the font-size and also force wrap the text but that would break
     ASCII art and other things that need to align across lines.
 
-    Arguably the font-size is too large on desktop. Perhaps it could be clamped but
-    that would leave a lot of whitespace to the right. We could reduce the entire
-    container width per-RFC but that would be an unusual website design choice.
-
     The MAGIC_SCALING_NUMBER could have a few more decimal places.
 
     The first table's 'Optimal font-size' was done manually in the browser dev tools
@@ -186,7 +182,31 @@ pre {
     /* Default font size for browsers that don't support cqi container units */
     font-size: 16px;
     --magic-scaling-number: 165;
-    font-size: calc((var(--magic-scaling-number) / var(--preformatted-max-line-length)) * 1cqi);
+
+    /* the basic responsive font-size
+    calc() supported in chrome 26/firefox 16, and CSS variables in chrome 49/firefox 31,
+    so this is 2014 era CSS
+     */
+    --responsive-font-size: calc((var(--magic-scaling-number) / var(--preformatted-max-line-length)) * 1cqi);
+
+    /*
+    set the font-size in several ways for different browser support
+    ===============================================================
+    */
+    /*
+    var() supported in chrome 49/firefox 31,
+    so this is 2014 era CSS
+    */
+    font-size: var(--responsive-font-size);
+    /*
+    min() supported in Chrome 96/Firefox 75
+    so this is 2020 era CSS that supporting browsers will use instead of the previous one
+    */
+    font-size: min(
+        var(--responsive-font-size),
+        /* max font-size on desktop */
+        1.2rem
+    );
 }
 
 @media only screen {

--- a/client/assets/css/upstream-xml2rfc.css
+++ b/client/assets/css/upstream-xml2rfc.css
@@ -1040,7 +1040,7 @@ td {
 tr {
   break-inside: avoid;
 }
-tr:nth-child(2n+1) > td {
+tr:nth-child(even) > td {
   background-color: rgba(0,0,0,0.1);
 }
 /* Use style rules to govern display of the TOC. */

--- a/client/components/RFCDocumentBody.vue
+++ b/client/components/RFCDocumentBody.vue
@@ -149,12 +149,22 @@ const renderDocumentPojo = (nodes: DocumentPojo): VNode => {
   const children = nodes.map(renderNodePojo)
   return h(Fragment, () => children)
 }
+
+const hasTouchStore = useHasTouchStore()
+
+const maxPreformattedLineLength = computed(() =>
+  hasTouchStore.hasTouch ?
+    props.rfcBucketHtmlDocument.maxPreformattedLineLength.maxWithAnchorSuffix :
+    props.rfcBucketHtmlDocument.maxPreformattedLineLength.max
+)
 </script>
 
 <style lang="postcss">
 /** Note that this is postcss so we can use @nested-import */
 
 .rfc-content {
+  --layout-bleed-left: 10px;
+  --layout-bleed-right: 10px;
 
   ol,
   ul {
@@ -164,9 +174,6 @@ const renderDocumentPojo = (nodes: DocumentPojo): VNode => {
 }
 
 .rfc-content-type-xml2rfc {
-  --layout-bleed-left: 10px;
-  --layout-bleed-right: 10px;
-
   /* Using postcss-nested-import to scope these imported styles,
      so that we can sandbox them and use them safely without major changes,
      to reduce maintenance burden.
@@ -182,8 +189,10 @@ html.dark .rfc-content-type-xml2rfc {
   /** container used to scale `font-size` with units like `cqi`
       https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries
   */
+  padding-left: var(--layout-bleed-left);
+  padding-right: var(--layout-bleed-right);
   container-type: inline-size;
-  --preformatted-max-line-length: v-bind(props.rfcBucketHtmlDocument.maxPreformattedLineLength);
+  --preformatted-max-line-length: v-bind(maxPreformattedLineLength);
 
   /* Using postcss-nested-import scope these imported styles */
   @nested-import "../assets/css/rfc-plaintext.css";

--- a/client/pages/info/[id].vue
+++ b/client/pages/info/[id].vue
@@ -32,10 +32,10 @@ import { DateTime } from 'luxon'
 import type { Rfc } from '~/generated/red-client'
 import { useRfcEditorHead } from '~/utilities/head'
 import { safeJsonParse } from '~/utilities/json'
+import { fetchRetry } from '~/utilities/network'
 import { parseRFCId } from '~/utilities/rfc'
 import { rfcToRfcCommon } from '~/utilities/rfc-converters'
 import { RfcBucketHtmlDocumentSchema } from '~/utilities/rfc-validators'
-
 import {
   apiRfcDocRetrievePathBuilder,
   apiRfcBucketDocumentURLBuilder,
@@ -65,7 +65,7 @@ const { data: rfcBucketHtmlDocument, error: rfcBucketHtmlDocumentError } = await
   `info-buckethtmldocument-${sanitisedId}`,
   async () => {
     const url = apiRfcBucketDocumentURLBuilder(rfcNumber)
-    const response = await fetch(url)
+    const response = await fetchRetry(url)
     if (!response.ok) {
       throw Error(`${response.status}: ${response.statusText} ${url}`)
     }
@@ -76,7 +76,6 @@ const { data: rfcBucketHtmlDocument, error: rfcBucketHtmlDocumentError } = await
       console.log(errorTitle, maybeRfcBucketDocument)
       throw Error(`${errorTitle}. See console for more.`)
     }
-    console.log(url, "[DIS[", Object.keys(!maybeRfcBucketDocument), JSON.stringify(maybeRfcBucketDocument, null, 2), "]")
     const { data, error } = RfcBucketHtmlDocumentSchema.safeParse(maybeRfcBucketDocument)
     if (error) {
       console.log('Failed to validate', JSON.stringify(maybeRfcBucketDocument, null, 2), error)
@@ -85,7 +84,7 @@ const { data: rfcBucketHtmlDocument, error: rfcBucketHtmlDocumentError } = await
     return data
   })
 
-if (rfcDocRetrieveError.value || rfcBucketHtmlDocumentError.value) {
+if (rfcDocRetrieveError.value) {
   console.error(rfcDocRetrieveError.value, rfcBucketHtmlDocumentError.value)
   throw createError({
     statusCode: 404,
@@ -94,7 +93,17 @@ if (rfcDocRetrieveError.value || rfcBucketHtmlDocumentError.value) {
   })
 }
 
-const canonicalUrl = infoRfcPathBuilder(`rfc${rfcNumber}`)
+if (rfcBucketHtmlDocumentError.value) {
+  console.error(rfcBucketHtmlDocumentError.value)
+  throw createError({
+    statusCode: 500,
+    statusMessage: `Unable to load RFC content JSON from ${apiRfcBucketDocumentURLBuilder(rfcNumber)
+      } ${rfcBucketHtmlDocumentError.value}`,
+    fatal: true
+  })
+}
+
+const canonicalUrl = infoRfcPathBuilder(sanitisedId)
 
 useRfcEditorHead({
   title: rfcDocRetrieve.value?.title ?? '',

--- a/client/utilities/network.ts
+++ b/client/utilities/network.ts
@@ -5,6 +5,9 @@ type FetchOptions = NonNullable<Parameters<typeof fetch>[1]>
 const MAX_RETRIES_DEFAULT = 2
 const DELAY_BETWEEN_RETRIES_MS_DEFAULT = 200
 
+/** a `fetch()` wrapper that retries if there's a failure,
+   working around transient network errors (ie WiFi connectivity)
+*/
 export const fetchRetry = (
   url: string,
   fetchOptions?: FetchOptions,

--- a/client/utilities/rfc-validators.ts
+++ b/client/utilities/rfc-validators.ts
@@ -195,6 +195,11 @@ export type NodePojo = z.infer<typeof NodeSchema>
 // pojo = plain old javascript object, rather than an instanceof Document class
 export type DocumentPojo = NodePojo[]
 
+const MaxPreformattedLineLengthSchema = z.object({
+  max: z.number(),
+  maxWithAnchorSuffix: z.number()
+})
+
 /**
  * Bucket JSON schema
  */
@@ -203,7 +208,7 @@ export const RfcBucketHtmlDocumentSchema = z.object({
   tableOfContents: TableOfContentsSchema.optional(),
   documentHtmlType: DocumentHtmlTypeSchema,
   documentHtmlObj: z.array(NodeSchema),
-  maxPreformattedLineLength: z.number()
+  maxPreformattedLineLength: MaxPreformattedLineLengthSchema
 })
 
 export type RfcBucketHtmlDocument = z.infer<typeof RfcBucketHtmlDocumentSchema>


### PR DESCRIPTION
## fix

In plaintext RFCs we have a calculated `font-size` based on the max line length of the individual RFC.

Although we were calculating the max line length correctly, when inline links (anchors) are present there's additional width only on mobile for buttons to trigger RFC link previews. This means the max line length varies between touch and touchless devices.

This change updates the bucket HTML doc schema to include max line length measurements for both cases, rather than just touchless.