### PR TITLE
Fix nuxt router unmount bug

### DIFF
--- a/client/app/components/RFCCard.vue
+++ b/client/app/components/RFCCard.vue
@@ -3,21 +3,19 @@
     :href="infoRfcPathBuilder(`RFC${props.rfc.number}`)"
     :heading-level="props.headingLevel"
     has-cover-link
-    :chevron-position="
-      props.rfc.abstract && responsiveModeStore.responsiveMode === 'Desktop' ?
-        'center'
+    :chevron-position="props.rfc.abstract && responsiveModeStore.responsiveMode === 'Desktop' ?
+      'center'
       : 'end'
-    "
+      "
     :class="props.showAbstract && props.rfc.abstract ? 'lg:flex' : undefined"
     :default-slot-class="props.showAbstract && props.rfc.abstract ? 'pr-4' : ''"
-    :aside-slot-class="
-      props.showAbstract && props.rfc.abstract ?
-        'flex-1 lg:w-1/2 xl:w-3/5 border-l pl-12 pr-4'
+    :aside-slot-class="props.showAbstract && props.rfc.abstract ?
+      'flex-1 lg:w-1/2 xl:w-3/5 border-l pl-12 pr-4'
       : undefined
-    "
+      "
   >
     <template #headingTitle>
-      <component :is="formatTitleAsVNode(`rfc${props.rfc.number}`)" />
+      <component :is="formattedTitle" />
     </template>
     <template #afterHeadingTitle>
       <span v-if="props.rfc.subseries">
@@ -27,13 +25,7 @@
           class="relative z-50 no-underline hover:underline focus:underline px-2 py-3 rounded text-gray-700"
           :title="`part of ${props.rfc.subseries.type.toUpperCase()}${props.rfc.subseries.number}`"
         >
-          <component
-            :is="
-              formatTitleAsVNode(
-                `${props.rfc.subseries.type}${props.rfc.subseries.number}`
-              )
-            "
-          />
+          <component :is="formattedSubseriesTitle" />
         </NuxtLink>
       </span>
     </template>
@@ -55,9 +47,7 @@
         >
           Abstract
         </Heading>
-        <p
-          class="leading-snug text-gray-800 dark:text-gray-300 pb-2 text-pretty"
-        >
+        <p class="leading-snug text-gray-800 dark:text-gray-300 pb-2 text-pretty">
           {{ props.rfc.abstract }}
         </p>
       </div>
@@ -84,6 +74,12 @@ const props = withDefaults(defineProps<Props>(), { headingLevel: '1' })
 const abstractHeadingLevel = computed(() =>
   parseHeadingLevel((parseFloat(props.headingLevel) + 1).toString())
 )
+
+const formattedTitle = computed(() => formatTitleAsVNode(`rfc${props.rfc.number}`))
+
+const formattedSubseriesTitle = computed(() => props.rfc.subseries ? formatTitleAsVNode(
+  `${props.rfc.subseries.type}${props.rfc.subseries.number}`
+) : undefined)
 
 const responsiveModeStore = useResponsiveModeStore()
 </script>

--- a/client/app/components/RFCDocumentBody.vue
+++ b/client/app/components/RFCDocumentBody.vue
@@ -24,7 +24,7 @@
     level="1"
     class="mb-2 pl-2 xs:px-0 print:px-0"
   >
-    <component :is="formatTitleAsVNode(`${rfcId.type}${rfcId.number}`)" />
+    <component :is="formattedTitle" />
   </Heading>
 
   <Heading
@@ -45,13 +45,11 @@
       For more information, please refer to
       <ul>
         <li
-          v-for="(obsoletedByItem, obsoletedByItemIndex) in props.rfc
-            .obsoleted_by"
+          v-for="(obsoletedByItem, obsoletedByItemIndex) in obsoletedBy"
           :key="obsoletedByItemIndex"
         >
-          <A :href="infoRfcPathBuilder(`RFC${obsoletedByItem.number}`)">
-            <component :is="formatTitleAsVNode(`RFC${obsoletedByItem.number}`)" />
-            {{ obsoletedByItem.title }}
+          <A :href="obsoletedByItem.href">
+            <component :is="obsoletedByItem.formattedTitle" />
           </A>
         </li>
       </ul>
@@ -98,6 +96,17 @@ const props = defineProps<Props>()
 const isModalOpen = defineModel<boolean>('isModalOpen')
 
 const rfcId = computed(() => parseRFCId(`rfc${props.rfc.number}`))
+
+const formattedTitle = computed(() => formatTitleAsVNode(`${rfcId.value.type}${rfcId.value.number}`))
+
+const obsoletedBy = computed(() => props.rfc.obsoleted_by?.map(obsoletedByItem => ({
+  href: infoRfcPathBuilder(`RFC${obsoletedByItem.number}`),
+  formattedTitle: h('span', [
+    formatTitleAsVNode(`RFC${obsoletedByItem.number}`),
+    ' ',
+    obsoletedByItem.title
+  ])
+})))
 
 const enrichedDocument = computed<VNode>(() =>
   renderDocumentPojo(props.rfcBucketHtmlDocument.documentHtmlObj)

--- a/client/app/components/RFCDocumentBody.vue
+++ b/client/app/components/RFCDocumentBody.vue
@@ -59,7 +59,7 @@
   <div
     :class="`rfc-content rfc-content-type-${props.rfcBucketHtmlDocument.documentHtmlType} wrap-anywhere mt-10 sm:text-base lg:text-base`"
   >
-    <Renderable :val="enrichedDocument" />
+    <component :is="enrichedDocument" />
   </div>
 
   <RFCMobileBanner


### PR DESCRIPTION
## fix

* Nuxt's SPA router was errorring when leaving `/info/rfcN/` routes. This fixes it.

## chore

* using `computed()` to cache the computation of some VNodes that were formatted text