### PR TITLE
fix: touch button in <pre>

### DIFF
--- a/client/app/components/RFCDocumentBody.vue
+++ b/client/app/components/RFCDocumentBody.vue
@@ -154,12 +154,8 @@ const renderDocumentPojo = (nodes: DocumentPojo): VNode => {
   return h(Fragment, () => children)
 }
 
-const hasTouchStore = useHasTouchStore()
-
 const maxPreformattedLineLength = computed(() =>
-  hasTouchStore.hasTouch ?
-    props.rfcBucketHtmlDocument.maxPreformattedLineLength.maxWithAnchorSuffix :
-    props.rfcBucketHtmlDocument.maxPreformattedLineLength.max
+  props.rfcBucketHtmlDocument.maxPreformattedLineLength.max
 )
 </script>
 
@@ -174,6 +170,17 @@ const maxPreformattedLineLength = computed(() =>
   ul {
     /* revert some tailwind reset styles because the imported CSS expect different defaults */
     all: revert;
+  }
+
+  pre .hide-in-preformatted-text {
+    /* 
+      The touch-based UX for RFCRouterLink inserts buttons after RFC links which
+      breaks <pre> layout so we hide the buttons in <pre> sections.
+
+      The pointer-based UX still works, as does the touch-based UX in non-<pre>
+      sections.      
+    */
+    display: none;
   }
 }
 

--- a/client/app/components/RFCRouterLink.vue
+++ b/client/app/components/RFCRouterLink.vue
@@ -43,13 +43,13 @@
     </HoverCardPortal>
   </HoverCardRoot>
 
-  <div
+  <span
     v-if="hasTouchStore.hasTouch === true"
     class="inline"
   >
     <DialogRoot v-model:open="isDialogOpen">
       <DialogTrigger
-        class="ml-1 px-1 align-baseline"
+        class="ml-1 px-1 align-baseline hide-in-preformatted-text"
         @focus="loadRfc"
         @mouseover="loadRfc"
       >
@@ -87,7 +87,7 @@
         </DialogContent>
       </DialogPortal>
     </DialogRoot>
-  </div>
+  </span>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## fix

* hide RFCRouterLink touch buttons in `<pre>`  as the inserted content breaks fixed `<pre>` layouts