### PR TITLE
feat: RFC 'info' page improvements

### DIFF
--- a/client/app/assets/css/tailwind.css
+++ b/client/app/assets/css/tailwind.css
@@ -111,10 +111,6 @@
       text-decoration: underline;
     }
   }
-
-  p {
-    line-height: 2;
-  }
 }
 
 html {

--- a/client/app/assets/css/upstream-xml2rfc.css
+++ b/client/app/assets/css/upstream-xml2rfc.css
@@ -36,17 +36,6 @@ h6 {
   font-weight: bold;
   padding: 0 var(--layout-bleed-right) 0 var(--layout-bleed-left);
 }
-#title,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-li,
-address {
-  line-height: 1.5;
-}
 
 #title {
   clear: both;
@@ -170,19 +159,15 @@ ul.compact,
 .ulCompact,
 ol.compact,
 .olCompact {
-  line-height: 1.5;
   margin: 0 0 0 2em;
 }
 
 /* definition lists */
-dl {
-}
 dl > dt {
   clear: both;
   float: left;
   padding-left: var(--layout-bleed-left);
   padding-right: var(--layout-bleed-right);
-  line-height: 1.5;
 }
 /* 
 dl.nohang > dt {
@@ -788,7 +773,6 @@ section {
 }
 
 /* Fix the height/width aspect for ascii art*/
-.sourcecode pre,
 .art-text pre {
   line-height: 1.5;
 }
@@ -1147,15 +1131,6 @@ dt code {
 /* Tweak the pre margin -- 0px doesn't come out well */
 pre {
   margin-top: 0.5px;
-}
-/* Tweak the compact list text */
-ul.compact,
-.ulCompact,
-ol.compact,
-.olCompact,
-dl.compact,
-.dlCompact {
-  line-height: normal;
 }
 /* Don't add top margin for nested lists */
 li > ul,

--- a/client/app/assets/css/upstream-xml2rfc.css
+++ b/client/app/assets/css/upstream-xml2rfc.css
@@ -170,7 +170,7 @@ ul.compact,
 .ulCompact,
 ol.compact,
 .olCompact {
-  line-height: 100%;
+  line-height: 1.5;
   margin: 0 0 0 2em;
 }
 
@@ -178,10 +178,11 @@ ol.compact,
 dl {
 }
 dl > dt {
+  clear: both;
   float: left;
   padding-left: var(--layout-bleed-left);
   padding-right: var(--layout-bleed-right);
-  line-height: 2;
+  line-height: 1.5;
 }
 /* 
 dl.nohang > dt {
@@ -389,22 +390,6 @@ hr {
   float: right;
 }
 
-/* table of contents */
-#toc {
-  padding: 0.75em 0 2em 0;
-  margin-bottom: 1em;
-}
-nav.toc ul {
-  margin: 0 0.5em 0 0;
-  padding: 0;
-  list-style: none;
-}
-nav.toc li {
-  line-height: 1.3em;
-  margin: 0.75em 0;
-  padding-left: 1.2em;
-  text-indent: -1.2em;
-}
 /* references */
 .references dt {
   text-align: right;
@@ -805,7 +790,7 @@ section {
 /* Fix the height/width aspect for ascii art*/
 .sourcecode pre,
 .art-text pre {
-  line-height: 1.12;
+  line-height: 1.5;
 }
 
 /* Add styling for a link in the ToC that points to the top of the document */
@@ -935,13 +920,6 @@ h4 {
   padding-top: 24px;
 }
 /* Float artwork pilcrow to the right */
-@media screen {
-  .artwork a.pilcrow {
-    display: block;
-    line-height: 0.7;
-    margin-top: 0.15em;
-  }
-}
 /* Make pilcrows on dd visible */
 @media screen {
   dd:hover > a.pilcrow {

--- a/client/app/components/AbsoluteHorizontalScrollable.vue
+++ b/client/app/components/AbsoluteHorizontalScrollable.vue
@@ -1,5 +1,4 @@
 <template>
-  <br /><!--linebreak to ensure eg list item • is visible -->
   <HorizontalScrollable :class="`absolute left-0 ${props.class ? props.class : ''}`">
     <slot />
   </HorizontalScrollable>

--- a/client/app/components/AbsoluteHorizontalScrollable.vue
+++ b/client/app/components/AbsoluteHorizontalScrollable.vue
@@ -1,4 +1,5 @@
 <template>
+  <br /><!--linebreak to ensure eg list item • is visible -->
   <HorizontalScrollable :class="`absolute left-0 ${props.class ? props.class : ''}`">
     <slot />
   </HorizontalScrollable>

--- a/client/app/components/AprilFools.vue
+++ b/client/app/components/AprilFools.vue
@@ -1,0 +1,8 @@
+<template>
+    <Icon
+        name="fa6-solid:masks-theater"
+        size="1em"
+        class="text-violet-500 -mb-0.5"
+        title="April Fools RFC"
+    />
+</template>

--- a/client/app/components/Breadcrumbs.vue
+++ b/client/app/components/Breadcrumbs.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul :class="['block mt-1 mb-1 px-1 xs:px-0', props.class]">
+  <ul :class="['block mt-1 mb-1 px-1 xs:px-0 print:hidden', props.class]">
     <li
       v-for="(path, index) in props.breadcrumbItems"
       :key="index"

--- a/client/app/components/Footer.vue
+++ b/client/app/components/Footer.vue
@@ -45,6 +45,7 @@
         </div>
       </div>
     </div>
+    <ScrollToTop />
   </footer>
 </template>
 

--- a/client/app/components/Header.vue
+++ b/client/app/components/Header.vue
@@ -2,6 +2,7 @@
   <header
     class="flex-1 bg-blue-900 text-white dark:bg-blue-950 relative print:hidden"
   >
+    <a id="top"></a>
     <HeaderSkipToContent />
     <nav class="container mx-auto flex justify-between py-4 px-2 w-full">
       <GraphicsHeaderLogos />

--- a/client/app/components/HeaderNavDesktop.vue
+++ b/client/app/components/HeaderNavDesktop.vue
@@ -4,10 +4,11 @@
     class="relative w-full z-90 justify-end content-end hidden lg:block"
     disable-hover-trigger
   >
-    <NavigationMenuList
-      class="m-0 flex gap-2 w-full justify-end list-none rounded-md"
-    >
-      <NavigationMenuItem v-for="(menuItem, index) in menuData" :key="index">
+    <NavigationMenuList class="m-0 flex gap-2 w-full justify-end list-none rounded-md">
+      <NavigationMenuItem
+        v-for="(menuItem, index) in menuData"
+        :key="index"
+      >
         <NavigationMenuLink
           v-if="menuItem.href && !menuItem.children"
           :href="menuItem.href"
@@ -15,7 +16,10 @@
           class="hover:bg-blue-400 group flex select-none items-center justify-between gap-[2px] rounded-md px-4 py-3 text-[15px] leading-none outline-none focus:shadow-[0_0_0_2px]"
           @click="menuItem.click"
         >
-          <Icon v-if="menuItem.icon" :name="menuItem.icon" />
+          <Icon
+            v-if="menuItem.icon"
+            :name="menuItem.icon"
+          />
         </NavigationMenuLink>
 
         <NavigationMenuTrigger
@@ -23,7 +27,10 @@
           class="hover:bg-blue-400 group flex select-none items-center justify-between gap-2 rounded-md px-4 py-3 text-[15px] leading-none outline-none focus:shadow-[0_0_0_2px]"
           :aria-label="menuItem.label"
         >
-          <Icon v-if="menuItem.icon" :name="menuItem.icon" />
+          <Icon
+            v-if="menuItem.icon"
+            :name="menuItem.icon"
+          />
           <span v-if="!menuItem.hideLabelDesktop">
             {{ menuItem.label }}
           </span>
@@ -54,7 +61,10 @@
                   >
                     <NavigationMenuTrigger :class="MENU_ITEM_CLASS">
                       <span>
-                        <Icon v-if="level0.icon" :name="level0.icon" />
+                        <Icon
+                          v-if="level0.icon"
+                          :name="level0.icon"
+                        />
                         {{ level0.label }}
                       </span>
                       <GraphicsChevron
@@ -76,7 +86,10 @@
                             :class="[MENU_ITEM_CLASS, 'pl-5']"
                             @click="level1.click"
                           >
-                            <Icon v-if="level1.icon" :name="level1.icon" />
+                            <Icon
+                              v-if="level1.icon"
+                              :name="level1.icon"
+                            />
                             {{ level1.label }}
                           </NavigationMenuLink>
                         </li>
@@ -85,7 +98,10 @@
                   </NavigationMenuItem>
                 </NavigationMenuList>
               </NavigationMenuSub>
-              <NavigationMenuLink v-else as-child>
+              <NavigationMenuLink
+                v-else
+                as-child
+              >
                 <A
                   v-if="level0.href"
                   :href="level0.href"
@@ -93,7 +109,10 @@
                   @click="level0.click"
                 >
                   <span>
-                    <Icon v-if="level0.icon" :name="level0.icon" />
+                    <Icon
+                      v-if="level0.icon"
+                      :name="level0.icon"
+                    />
                     {{ level0.label }}
                     <Icon
                       v-if="!isInternalLink(level0.href)"
@@ -110,15 +129,18 @@
                   @click="level0.click"
                 >
                   <span class="flex items-center">
-                    <Icon v-if="level0.icon" :name="level0.icon" />
                     <Icon
-                      v-if="level0.isActiveFn?.()"
+                      v-if="level0.icon"
+                      :name="level0.icon"
+                    />
+                    <Icon
+                      v-if="Boolean(level0.isActiveFn?.())"
                       name="fluent:checkmark-12-filled"
                       class="inline-block w-[14px] h-[14px] mr-2"
                     />
                     <span
                       v-if="
-                        level0.isActiveFn && !level0.isActiveFn() // render blank space
+                        Boolean(level0.isActiveFn && !level0.isActiveFn())
                       "
                       class="inline-block w-[14px] h-[14px] mr-2"
                     />

--- a/client/app/components/HorizontalScrollable.vue
+++ b/client/app/components/HorizontalScrollable.vue
@@ -3,7 +3,7 @@
     :is="props.as"
     ref="scroll-container"
     :class="[
-      'w-full max-w-[100vw] overflow-x-auto transition-shadow duration-800',
+      'w-full max-w-[calc(100vw_-_var(--scrollbar-width))] overflow-x-auto transition-shadow duration-800',
       props.class,
       {
         'shadow-[inset_70px_0px_90px_-70px_rgba(0,_45,_60,_0.5),inset_36px_0px_20px_-36px_rgba(0,_45,_60,_0.5)] dark:shadow-[inset_70px_0px_90px_-70px_rgba(140,_201,_222,_0.5),inset_36px_0px_20px_-36px_rgba(140,_201,_222,_0.5)]':
@@ -13,13 +13,14 @@
         'shadow-[inset_70px_0px_90px_-70px_rgba(0,_45,_60,_0.5),inset_-70px_0px_90px_-70px_rgba(0,_45,_60,_0.5)] dark:shadow-[inset_70px_0px_90px_-70px_rgba(140,_201,_222,_0.5),inset_-70px_0px_90px_-70px_rgba(140,_201,_222,_0.5)]':
           canScrollLeft && canScrollRight
       }]"
-    @scroll="updateScrollHint"
+    @scroll="debouncedUpdateScrollHint"
   >
     <slot />
   </component>
 </template>
 
 <script setup lang="ts">
+import { useDebounceFn } from '@vueuse/core'
 import type { VueStyleClass } from '~/utilities/vue'
 
 type Props = {
@@ -53,13 +54,15 @@ const updateScrollHint = () => {
     scrollContainerElement.scrollWidth - BUFFER_PX
 }
 
+const debouncedUpdateScrollHint = useDebounceFn(updateScrollHint, 100)
+
 onMounted(() => {
-  window.addEventListener('resize', updateScrollHint)
+  window.addEventListener('resize', debouncedUpdateScrollHint)
   timer = setTimeout(updateScrollHint, 50)
 })
 
 onUnmounted(() => {
-  window.removeEventListener('resize', updateScrollHint)
+  window.removeEventListener('resize', debouncedUpdateScrollHint)
   if (timer) {
     clearTimeout(timer)
   }

--- a/client/app/components/Pill.vue
+++ b/client/app/components/Pill.vue
@@ -1,23 +1,21 @@
 <template>
-  <div
-    :class="[
-      'inline-flex rounded-lg overflow-hidden print:text-sm',
-      props.class,
-      {
-        'text-sm font-semibold': props.size === 'normal',
-        'text-xs font-semibold': props.size === 'small'
-      }
-    ]"
-  >
+  <div :class="[
+    'inline-flex rounded-lg overflow-hidden print:text-sm print:leading-[2]',
+    props.class,
+    {
+      'text-sm font-semibold': props.size === 'normal',
+      'text-xs font-semibold': props.size === 'small'
+    }
+  ]">
     <div
       v-for="(textItem, index) in props.text"
       :key="index"
       :class="{
-        'py-1 uppercase': true,
+        'py-1 uppercase print:text-black print:bg-transparent print:border-1 print:border-black': true,
         'px-2': props.size === 'small',
         'px-3': props.size === 'normal',
         'bg-blue-400 dark:bg-blue-800 text-white print:bg-white': index === 0,
-        'bg-yellow-200 dark:bg-yellow-700 dark:text-white text-black print:text-black print:bg-white':
+        'bg-yellow-200 dark:bg-yellow-700 dark:text-white text-black':
           index === 1,
         'bg-blue-300 dark:bg-blue-700': index >= 1
       }"

--- a/client/app/components/RFCCardBody.vue
+++ b/client/app/components/RFCCardBody.vue
@@ -29,11 +29,7 @@
         v-if="isAprilFool"
         class="inline pr-2"
       >
-        <Icon
-          name="fa6-solid:masks-theater"
-          size="1em"
-          class="text-violet-500 -mb-0.5"
-        />
+        <AprilFools />
       </li>
       <li
         v-for="(part, index) in list2"

--- a/client/app/components/RFCDocumentBody.vue
+++ b/client/app/components/RFCDocumentBody.vue
@@ -94,6 +94,7 @@
 <script setup lang="ts">
 import { createTextVNode } from 'vue'
 import { pickBy } from 'lodash-es'
+import { DateTime } from 'luxon'
 import AMaybeRFCLink from './AMaybeRFCLink.vue'
 import HorizontalScrollable from './HorizontalScrollable.vue'
 import AbsoluteHorizontalScrollable from './AbsoluteHorizontalScrollable.vue'
@@ -108,7 +109,6 @@ import { infoRfcPathBuilder } from '~/utilities/url'
 import type { BreadcrumbItem } from '~/components/BreadcrumbsTypes'
 import type { DocumentPojo, ElementPojo, NodePojo } from '~/utilities/rfc-validators'
 import { COMMA, NONBREAKING_SPACE } from '~/utilities/strings'
-import { DateTime } from 'luxon'
 
 type Props = {
   rfc: RfcCommon

--- a/client/app/components/RFCDocumentBody.vue
+++ b/client/app/components/RFCDocumentBody.vue
@@ -17,19 +17,26 @@
 
   <Heading
     level="1"
-    class="mb-2 pl-2 xs:px-0 print:px-0"
+    class="mb-2 pl-2 xs:px-0 print:mt-5 print:text-lg print:border-b-2 print:border-black print:text-center"
   >
     <component :is="formattedTitle" />
   </Heading>
 
   <Heading
     level="2"
-    class="mb-2 pl-2 xs:px-0 print:px-0"
+    class="mb-2 pl-2 xs:px-0 print:text-center"
   >
     {{ rfc.title }}
+
+    <span
+      v-if="isAprilFool"
+      class="inline pr-2"
+    >
+      <AprilFools />
+    </span>
   </Heading>
 
-  <ul class="block ml-2">
+  <ul class="block ml-2 print:text-center">
     <li
       v-for="(author, authorIndex) in props.rfc.authors"
       :key="authorIndex"
@@ -68,9 +75,13 @@
     </div>
   </Alert>
 
-  <div
-    :class="`relative rfc-content rfc-content-type-${props.rfcBucketHtmlDocument.documentHtmlType} wrap-anywhere mt-5 sm:text-base lg:text-base`"
-  >
+  <div :class="`rfc-content rfc-content-type-${props.rfcBucketHtmlDocument.documentHtmlType} relative ${
+    //
+    ' leading-[1.75] ' // WCAG requires 1.5 minimum
+    } ${
+    //
+    ' wrap-normal ' // there are URLs as text in RFCs that need wrapping or they'll break the layout see rfc8889
+    } mt-5 sm:text-base lg:text-base`">
     <component :is="enrichedDocument" />
   </div>
 
@@ -97,6 +108,7 @@ import { infoRfcPathBuilder } from '~/utilities/url'
 import type { BreadcrumbItem } from '~/components/BreadcrumbsTypes'
 import type { DocumentPojo, ElementPojo, NodePojo } from '~/utilities/rfc-validators'
 import { COMMA, NONBREAKING_SPACE } from '~/utilities/strings'
+import { DateTime } from 'luxon'
 
 type Props = {
   rfc: RfcCommon
@@ -210,6 +222,11 @@ const renderDocumentPojo = (nodes: DocumentPojo): VNode => {
 const maxPreformattedLineLength = computed(() =>
   props.rfcBucketHtmlDocument.maxPreformattedLineLength.max
 )
+
+const isAprilFool = computed(() => {
+  const datetime = DateTime.fromISO(props.rfc.published)
+  return datetime.month === 4 && datetime.day === 1
+})
 </script>
 
 <style lang="postcss">

--- a/client/app/components/RFCDocumentBodyPill.vue
+++ b/client/app/components/RFCDocumentBodyPill.vue
@@ -1,14 +1,14 @@
 <template>
-    <div class="flex ml-2 flex-row justify-between items-center flex-wrap">
-        <div class="flex align-middle">
+    <div class="flex ml-2 flex-row justify-between items-center flex-wrap print:justify-center">
+        <div class="flex align-middle print:text-center">
             <Pill
                 v-if="tagText.length > 0"
                 size="normal"
                 :text="tagText"
-                class="print:m-0 my-2"
+                class="print:mt-3 my-2"
             />
             <PopoverRoot>
-                <PopoverTrigger class="p-2 cursor-help">
+                <PopoverTrigger class="p-2 cursor-help print:hidden">
                     <GraphicsQuestionMarkCircle />
                 </PopoverTrigger>
 
@@ -19,7 +19,7 @@
                         <PopoverArrow
                             class="fill-white stroke-gray-400 dark:fill-black dark:stroke-gray-300 relative -top-[1px]"
                         />
-                        <p>
+                        <p class="text-balance">
                             For the definition of <b>Status</b>, see
                             <A
                                 :href="infoRfcPathBuilder('rfc2026')"
@@ -28,7 +28,7 @@
                                 <component :is="formatTitleAsVNode('rfc2026')" />
                             </A>.
                         </p>
-                        <p>
+                        <p class="text-balance">
                             For the definition of <b>Stream</b>, see
                             <A
                                 :href="infoRfcPathBuilder('rfc8729')"

--- a/client/app/components/RFCRouterLinkPreview.vue
+++ b/client/app/components/RFCRouterLinkPreview.vue
@@ -63,7 +63,7 @@
   <p class="clear-both text-right mt-6 mb-10">
     <A
       :href="rfcPathBuilder(props.rfcJson.doc_id)"
-      class="flex-inline rounded no-underline justify-center items-center bg-gray-100 dark:bg-gray-700 text-blue-400 dark:text-white px-4 pt-3 pb-4 mr-6"
+      class="flex-inline rounded no-underline hover:underline focus:underline justify-center items-center bg-gray-100 dark:bg-gray-700 text-blue-400 dark:text-white px-4 pt-3 pb-4 mr-6"
     >
       <component :is="formattedTitle" />
       <GraphicsChevron class="ml-2 inline -rotate-90" />
@@ -72,7 +72,7 @@
 </template>
 
 <script setup lang="ts">
-// TODO: Track preview analytics
+// TODO: Track preview analytics as it might siphon off visitors to RFCs
 import { DateTime } from 'luxon'
 import { infoRfcPathBuilder, rfcPathBuilder } from '../utilities/url'
 import Anchor from './A.vue'

--- a/client/app/components/RFCTabs.vue
+++ b/client/app/components/RFCTabs.vue
@@ -311,7 +311,7 @@ const formattedPublished = computed(() => {
 })
 
 const TAB_CONTENT_CLASS = 'flex flex-col min-h-screen'
-const DEFAULT_CLASS = 'py-4 whitespace-nowrap border-b-2 text-sm md:text-md'
+const DEFAULT_CLASS = 'py-4 whitespace-nowrap border-b-2 hover:bg-gray-100 text-sm md:text-md cursor-pointer'
 const SELECTED_CLASS = 'text-shadow-bold text-gray-900 dark:text-gray-100 border-b-blue-900 dark:border-b-white font-medium'
 const UNSELECTED_CLASS = 'border-b-transparent text-gray-800 dark:text-gray-300'
 </script>

--- a/client/app/components/ScrollToTop.vue
+++ b/client/app/components/ScrollToTop.vue
@@ -1,0 +1,52 @@
+<template>
+    <a
+        :class="[
+            {
+                'opacity-0 pointer-events-none': !debouncedIsVisible,
+                'opacity-100': debouncedIsVisible
+            },
+            'fixed right-[10px] lg:right-[310px] top-0 text-black font-bold rounded-b z-10 bg-white hover:text-white focus:text-white hover:bg-blue-300 dark:bg-black dark:hover:bg-blue-500 border border-gray-200 dark:border-gray-600 px-3 py-2 font-lg transition-opacity print:hidden shadow-lg shadow-gray-300 dark:shadow-blue-900 dark:text-white focus:opacity-100 focus:pointer-events-auto',
+        ]"
+        href="#top"
+        title="Go to top of page"
+    >
+        <Icon
+            name="ion:md-skip-forward"
+            class="-rotate-90"
+        />
+    </a>
+</template>
+
+<script setup lang="ts">
+import { throttle } from 'lodash-es'
+import { debouncedRef } from '@vueuse/core'
+
+const isVisible = ref(false)
+const debouncedIsVisible = debouncedRef(isVisible, 200)
+
+const handleScroll = () => {
+    const scrollYThresholdPx = window.innerHeight
+    isVisible.value = Boolean(window.scrollY > scrollYThresholdPx)
+}
+
+const throttledHandleScroll = throttle(handleScroll, 100)
+
+onMounted(() => {
+    document.addEventListener('scroll', throttledHandleScroll, {
+        passive: true
+    })
+    document.addEventListener('scrollsnapchanging', throttledHandleScroll, {
+        passive: true
+    })
+    document.addEventListener('touchmove', throttledHandleScroll, {
+        passive: true
+    })
+    throttledHandleScroll()
+})
+
+onUnmounted(() => {
+    document.removeEventListener('scroll', throttledHandleScroll)
+    document.removeEventListener('scrollsnapchanging', throttledHandleScroll)
+    document.removeEventListener('touchmove', throttledHandleScroll)
+})
+</script>

--- a/client/app/components/VerticalScrollable.vue
+++ b/client/app/components/VerticalScrollable.vue
@@ -16,6 +16,7 @@
 
 <script setup lang="ts">
 import { useDebounceFn } from '@vueuse/core'
+
 const scrollContainer = useTemplateRef('scroll-container')
 const canScrollUp = ref(false)
 const canScrollDown = ref(false)

--- a/client/app/components/VerticalScrollable.vue
+++ b/client/app/components/VerticalScrollable.vue
@@ -8,13 +8,14 @@
       canScrollUp && canScrollDown && 'shadow-[inset_0px_70px_90px_-70px_rgba(0,_45,_60,_0.5),inset_0px_-70px_90px_-70px_rgba(0,_45,_60,_0.5)] dark:shadow-[inset_0px_70px_90px_-70px_rgba(140,_201,_222,_0.5),inset_0px_-70px_90px_-70px_rgba(140,_201,_222,_0.5)]',
       props.class
     ]"
-    @scroll="updateScrollHint"
+    @scroll="debouncedUpdateScrollHint"
   >
     <slot />
   </div>
 </template>
 
 <script setup lang="ts">
+import { useDebounceFn } from '@vueuse/core'
 const scrollContainer = useTemplateRef('scroll-container')
 const canScrollUp = ref(false)
 const canScrollDown = ref(false)
@@ -42,18 +43,20 @@ const updateScrollHint = () => {
     scrollContainerElement.scrollHeight - BUFFER_PX
 }
 
+const debouncedUpdateScrollHint = useDebounceFn(updateScrollHint, 100)
+
 let timer: ReturnType<typeof setTimeout>
 
 onMounted(() => {
-  window.addEventListener('resize', updateScrollHint)
+  window.addEventListener('resize', debouncedUpdateScrollHint)
 
-  updateScrollHint()
+  debouncedUpdateScrollHint()
 
   timer = setTimeout(updateScrollHint, 50)
 })
 
 onUnmounted(() => {
-  window.removeEventListener('resize', updateScrollHint)
+  window.removeEventListener('resize', debouncedUpdateScrollHint)
   if (timer) {
     clearTimeout(timer)
   }

--- a/client/app/utilities/head.ts
+++ b/client/app/utilities/head.ts
@@ -1,8 +1,7 @@
 import type { DateTime } from 'luxon'
 import { useHead } from 'nuxt/app'
 import { linkPreviewImageUrlBuilder } from './url'
-import type {
-  imagePreviewDimensions } from '#shared/utils/meta-preview-images'
+import type { imagePreviewDimensions } from '#shared/utils/meta-preview-images'
 import {
   OPENGRAPH_DIMENSIONS,
   TWITTER_DIMENSIONS

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -10,6 +10,8 @@ type RouteRules = NonNullable<
 const oneHourInSeconds = 60 * 60
 const oneDayInSeconds = 24 * oneHourInSeconds
 
+const scrollbarWidthInlineJS = `function _updateScrollbarWidth(){document.documentElement.style.setProperty('--scrollbar-width',(window.innerWidth-document.documentElement.clientWidth)+'px')}window.addEventListener('resize', _updateScrollbarWidth, false);document.addEventListener('DOMContentLoaded', _updateScrollbarWidth, false);window.addEventListener('load', _updateScrollbarWidth);`
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2025-08-05',
@@ -93,6 +95,15 @@ export default defineNuxtConfig({
         // used to scope RFC generator HTML styles
         // see @nested-import
       }
+    }
+  },
+  app: {
+    head: {
+      script: [
+        {
+          innerHTML: scrollbarWidthInlineJS
+        }
+      ]
     }
   },
   $production: {

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -10,6 +10,7 @@ type RouteRules = NonNullable<
 const oneHourInSeconds = 60 * 60
 const oneDayInSeconds = 24 * oneHourInSeconds
 
+// inserted in the <head> some inline JS to determine scrollbar width so that CSS can use it in calc()
 const scrollbarWidthInlineJS = `function _updateScrollbarWidth(){document.documentElement.style.setProperty('--scrollbar-width',(window.innerWidth-document.documentElement.clientWidth)+'px')}window.addEventListener('resize', _updateScrollbarWidth, false);document.addEventListener('DOMContentLoaded', _updateScrollbarWidth, false);window.addEventListener('load', _updateScrollbarWidth);`
 
 // https://nuxt.com/docs/api/configuration/nuxt-config


### PR DESCRIPTION
## feat

* Print CSS improvements for RFCs
* scroll to top link (see screenshot)
* scrollbar width now accounted for horizontally scrollable area math
* line-height reduced from 2 to 1.7 (line-height tidy up in RFC HTML CSS)
* April fools RFC icon on RFC 'info' page too.
* uses new `<wbr>` from [`red-rfc-html-extractor`](https://github.com/ietf-tools/red-rfc-html-extractor) so we shouldn't need CSS `overflow-wrap: anywhere;` :crossed_fingers: 

## chore

* debounced scroll handlers