### PR TITLE
fix: scroll to top button positioning. fix info modal deleting scroll…

### DIFF
--- a/client/app/components/HorizontalScrollable.vue
+++ b/client/app/components/HorizontalScrollable.vue
@@ -3,7 +3,7 @@
     :is="props.as"
     ref="scroll-container"
     :class="[
-      'w-full max-w-[calc(100vw_-_var(--scrollbar-width))] overflow-x-auto transition-shadow duration-800',
+      'w-full max-w-[calc(100vw_-_var(--rfc-editor-org-scrollbar-width,16px))] overflow-x-auto transition-shadow duration-800',
       props.class,
       {
         'shadow-[inset_70px_0px_90px_-70px_rgba(0,_45,_60,_0.5),inset_36px_0px_20px_-36px_rgba(0,_45,_60,_0.5)] dark:shadow-[inset_70px_0px_90px_-70px_rgba(140,_201,_222,_0.5),inset_36px_0px_20px_-36px_rgba(140,_201,_222,_0.5)]':

--- a/client/app/components/RFCDocumentBody.vue
+++ b/client/app/components/RFCDocumentBody.vue
@@ -4,15 +4,7 @@
       :breadcrumb-items="breadcrumbItems"
       class="flex-1"
     />
-    <button
-      type="button"
-      class="fixed right-0 mt-3 font-bold rounded-l z-10 bg-white dark:bg-black border border-r-0 border-gray-200 align-middle flex items-center px-3 py-2 text-sm lg:hidden print:hidden shadow-lg shadow-gray-300 dark:shadow-blue-900"
-      aria-label="Open details modal"
-      @click="isModalOpen = true"
-    >
-      <GraphicsExpandSidebar class="inline-block mr-1" />
-      Info
-    </button>
+    <RFCDocumentMobileInfoButton @click="isModalOpen = true">Info</RFCDocumentMobileInfoButton>
   </div>
 
   <Heading
@@ -75,13 +67,10 @@
     </div>
   </Alert>
 
-  <div :class="`rfc-content rfc-content-type-${props.rfcBucketHtmlDocument.documentHtmlType} relative ${
+  <div :class="`rfc-content rfc-content-type-${props.rfcBucketHtmlDocument.documentHtmlType} relative mt-5 sm:text-base lg:text-base ${
     //
     ' leading-[1.75] ' // WCAG requires 1.5 minimum
-    } ${
-    //
-    ' wrap-normal ' // there are URLs as text in RFCs that need wrapping or they'll break the layout see rfc8889
-    } mt-5 sm:text-base lg:text-base`">
+    }`">
     <component :is="enrichedDocument" />
   </div>
 

--- a/client/app/components/RFCDocumentMobileInfoButton.vue
+++ b/client/app/components/RFCDocumentMobileInfoButton.vue
@@ -1,0 +1,9 @@
+<template>
+    <button
+        type="button"
+        class="fixed top-12 right-0 mt-3 font-bold rounded-l z-10 bg-white dark:bg-black border border-r-0 border-gray-200 align-middle flex items-center px-3 py-2 text-sm lg:hidden print:hidden shadow-lg shadow-gray-300 dark:shadow-blue-900"
+        aria-label="Open RFC info modal"
+    >
+        <slot />
+    </button>
+</template>

--- a/client/app/components/RFCTabs.vue
+++ b/client/app/components/RFCTabs.vue
@@ -5,7 +5,7 @@
     @change="changeTab"
   >
     <TabsList class="border-b-2 border-gray-400">
-      <HorizontalScrollable class="flex flex-row gap-5">
+      <HorizontalScrollable :class="`flex flex-row gap-5 ${props.isMobile ? 'px-2' : ''}`">
         <TabsIndicator class="absolute" />
         <TabsTrigger
           v-if="props.hasTableOfContents"
@@ -98,7 +98,9 @@
     </TabsContent>
     <TabsContent
       :value="1"
-      :class="TAB_CONTENT_CLASS"
+      :class="[TAB_CONTENT_CLASS, {
+        'px-4': props.isMobile,
+      }]"
     >
       <Heading
         level="3"
@@ -241,7 +243,9 @@
     </TabsContent>
     <TabsContent
       :value="2"
-      :class="TAB_CONTENT_CLASS"
+      :class="[TAB_CONTENT_CLASS, {
+        'px-4': props.isMobile,
+      }]"
     >
       <p class="border-b-1 border-gray-200 py-6">
         <AValidHref

--- a/client/app/components/ScrollToTop.vue
+++ b/client/app/components/ScrollToTop.vue
@@ -5,15 +5,12 @@
                 'opacity-0 pointer-events-none': !debouncedIsVisible,
                 'opacity-100': debouncedIsVisible
             },
-            'fixed right-[10px] lg:right-[310px] top-0 text-black font-bold rounded-b z-10 bg-white hover:text-white focus:text-white hover:bg-blue-300 dark:bg-black dark:hover:bg-blue-500 border border-gray-200 dark:border-gray-600 px-3 py-2 font-lg transition-opacity print:hidden shadow-lg shadow-gray-300 dark:shadow-blue-900 dark:text-white focus:opacity-100 focus:pointer-events-auto',
+            'fixed top-1 right-2 lg:right-auto text-black font-bold rounded-b z-10 bg-white hover:text-white focus:text-white hover:bg-blue-300 dark:bg-black dark:hover:bg-blue-500 border border-gray-200 dark:border-gray-600 px-3 py-2 font-lg transition-opacity print:hidden shadow-lg shadow-gray-300 dark:shadow-blue-900 dark:text-white focus:opacity-100 focus:pointer-events-auto',
         ]"
         href="#top"
         title="Go to top of page"
     >
-        <Icon
-            name="ion:md-skip-forward"
-            class="-rotate-90"
-        />
+        <GraphicsExpandSidebar class="inline-block rotate-90" />
     </a>
 </template>
 

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -11,7 +11,7 @@ const oneHourInSeconds = 60 * 60
 const oneDayInSeconds = 24 * oneHourInSeconds
 
 // inserted in the <head> some inline JS to determine scrollbar width so that CSS can use it in calc()
-const scrollbarWidthInlineJS = `function _updateScrollbarWidth(){document.documentElement.style.setProperty('--scrollbar-width',(window.innerWidth-document.documentElement.clientWidth)+'px')}window.addEventListener('resize', _updateScrollbarWidth, false);document.addEventListener('DOMContentLoaded', _updateScrollbarWidth, false);window.addEventListener('load', _updateScrollbarWidth);`
+const scrollbarWidthInlineJS = `function _updateScrollbarWidth(){document.body.style.setProperty('--rfc-editor-org-scrollbar-width',(window.innerWidth-document.documentElement.clientWidth)+'px')}window.addEventListener('resize', _updateScrollbarWidth, false);document.addEventListener('DOMContentLoaded', _updateScrollbarWidth, false);window.addEventListener('load', _updateScrollbarWidth);`
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({


### PR DESCRIPTION
## fix

*  scroll to top button positioning fix. 
* info modal closing deletes css vars off `<html>`. Must be a library side-effect. Moved our CSS var to `<body>` instead and gave it a very unique name to hopefully make libs leave it alone.
* info modal padding etc
