### PR TITLE
chore: refactor 'info' page rfc loading

### DIFF
--- a/client/app/components/RFCDocument.vue
+++ b/client/app/components/RFCDocument.vue
@@ -2,19 +2,34 @@
   <BodyLayoutDocument>
     <template #sidebar>
       <RFCDocumentSidebar
+        v-if="rfc && rfcBucketHtmlDocument"
         v-model:selected-tab="selectedTab"
         v-model:is-modal-open="isModalOpen"
-        :rfc="props.rfc"
-        :rfc-bucket-html-document="props.rfcBucketHtmlDocument"
+        :rfc="rfc"
+        :rfc-bucket-html-document="rfcBucketHtmlDocument"
         :has-table-of-contents="hasToc"
         :goto-errata="gotoErrata"
         :change-tab="changeTab"
       />
     </template>
+    <template v-if="rfcDocRetrieveError || rfcBucketHtmlDocumentError">
+      <div class="container mx-auto">
+        <Alert
+          level="1"
+          variant="warning"
+          heading="Error"
+        >
+          {{ rfcDocRetrieveError }}
+          {{ rfcBucketHtmlDocumentError }}
+        </Alert>
+      </div>
+    </template>
+
     <RFCDocumentBody
+      v-if="rfc && rfcBucketHtmlDocument"
       v-model:is-modal-open="isModalOpen"
-      :rfc="props.rfc"
-      :rfc-bucket-html-document="props.rfcBucketHtmlDocument"
+      :rfc="rfc"
+      :rfc-bucket-html-document="rfcBucketHtmlDocument"
       :breadcrumb-items="breadcrumbItems"
       :goto-errata="gotoErrata"
       :change-tab="changeTab"
@@ -23,19 +38,90 @@
 </template>
 
 <script setup lang="ts">
-import type { RfcBucketHtmlDocument, RfcCommon } from '~/utilities/rfc'
+import { DateTime } from 'luxon'
+import { safeJsonParse } from '~/utilities/json'
+import { fetchRetry } from '~/utilities/network'
+import { rfcToRfcCommon } from '~/utilities/rfc-converters'
+import { RfcBucketHtmlDocumentSchema } from '~/utilities/rfc-validators'
+import {
+  apiRfcDocRetrievePathBuilder,
+  apiRfcBucketDocumentURLBuilder,
+  infoRfcPathBuilder,
+  rfcFormatPathBuilder,
+  PUBLIC_SITE
+} from '~/utilities/url'
+import { useRfcEditorHead } from '~/utilities/head'
+import type { RFCId } from '~/utilities/rfc'
 import type { BreadcrumbItem } from '~/components/BreadcrumbsTypes'
 
+import type { Rfc } from '~~/generated/red-client'
+
 type Props = {
-  rfc: RfcCommon
-  rfcBucketHtmlDocument: RfcBucketHtmlDocument
+  rfcId: RFCId
 }
 
 const props = defineProps<Props>()
 
+const sanitisedId = computed(() => `${props.rfcId.type}${props.rfcId.number}`)
+
+const asyncRfcDocRetrieveKey = computed(() => `info-docretrieve-${sanitisedId.value}`)
+const {
+  data: rfcDocRetrieve,
+  error: rfcDocRetrieveError
+} = await useAsyncData<Rfc>(asyncRfcDocRetrieveKey, async () =>
+  $fetch(apiRfcDocRetrievePathBuilder(parseInt(props.rfcId.number, 10)))
+)
+
+const rfc = computed(() => {
+  if (!rfcDocRetrieve.value) return
+  return rfcToRfcCommon(rfcDocRetrieve.value)
+})
+
+const asyncRfcBucketHtmlDocumentKey = computed(() => `info-buckethtmldocument-${sanitisedId.value}`)
+const { data: rfcBucketHtmlDocument, error: rfcBucketHtmlDocumentError } = await useAsyncData(
+  asyncRfcBucketHtmlDocumentKey,
+  async () => {
+    const url = apiRfcBucketDocumentURLBuilder(parseInt(props.rfcId.number, 10))
+    const response = await fetchRetry(url)
+    if (!response.ok) {
+      throw Error(`${response.status}: ${response.statusText} ${url}`)
+    }
+    const text = await response.text()
+    const maybeRfcBucketDocument = safeJsonParse(text)
+    if (typeof maybeRfcBucketDocument !== 'object') {
+      const errorTitle = `Expected JSON object from ${url} but received ${typeof maybeRfcBucketDocument}`
+      console.log(errorTitle, maybeRfcBucketDocument)
+      throw Error(`${errorTitle}. See console for more.`)
+    }
+    const { data, error } = RfcBucketHtmlDocumentSchema.safeParse(maybeRfcBucketDocument)
+    if (error) {
+      console.log('Failed to validate', JSON.stringify(maybeRfcBucketDocument, null, 2), error)
+      throw error
+    }
+    return data
+  })
+
+if (rfcDocRetrieveError.value) {
+  console.error(rfcDocRetrieveError.value, rfcBucketHtmlDocumentError.value)
+  throw createError({
+    statusCode: 404,
+    statusMessage: 'Not Found',
+    fatal: true
+  })
+}
+
+if (rfcBucketHtmlDocumentError.value) {
+  console.error(rfcBucketHtmlDocumentError.value)
+  throw createError({
+    statusCode: 404,
+    statusMessage: `No ${sanitisedId.value} content found. If this is a new RFC please try again later. Try also ${PUBLIC_SITE}${rfcFormatPathBuilder(sanitisedId.value, 'html')}`,
+    fatal: true
+  })
+}
+
 const hasToc = computed(() => Boolean(
-  props.rfcBucketHtmlDocument.tableOfContents?.sections &&
-  props.rfcBucketHtmlDocument.tableOfContents?.sections.length > 0
+  rfcBucketHtmlDocument.value?.tableOfContents?.sections &&
+  rfcBucketHtmlDocument.value?.tableOfContents?.sections.length > 0
 ))
 
 const selectedTab = ref(
@@ -78,4 +164,17 @@ const breadcrumbItems: BreadcrumbItem[] = [
 ]
 
 const isModalOpen = ref(false)
+
+const canonicalUrl = infoRfcPathBuilder(sanitisedId.value)
+
+useRfcEditorHead({
+  title: rfcDocRetrieve.value?.title ?? '',
+  canonicalUrl,
+  description: rfcDocRetrieve.value?.abstract ?? '',
+  modifiedDateTime:
+    rfcDocRetrieve.value?.published ?
+      DateTime.fromISO(rfcDocRetrieve.value.published)
+      : undefined,
+  contentType: 'article'
+})
 </script>

--- a/client/app/pages/info/[id].vue
+++ b/client/app/pages/info/[id].vue
@@ -1,48 +1,26 @@
 <template>
   <div class="min-h-[100vh]">
     <NuxtLayout name="white">
-      <template v-if="rfcDocRetrieveError || rfcBucketHtmlDocumentError">
+      <template v-if="rfcId.type === 'RFC'">
+        <RFCDocument :rfc-id="rfcId" />
+      </template>
+      <template v-else>
         <div class="container mx-auto">
           <Alert
             level="1"
             variant="warning"
             heading="Error"
           >
-            {{ rfcDocRetrieveError }}
-            {{ rfcBucketHtmlDocumentError }}
+            Unsupported {{ paramsId }}
           </Alert>
         </div>
-      </template>
-      <template v-else-if="
-        rfc &&
-        rfcDocRetrieveStatus === 'success' &&
-        rfcBucketHtmlDocument
-      ">
-        <RFCDocument
-          :rfc="rfc"
-          :rfc-bucket-html-document="rfcBucketHtmlDocument"
-        />
       </template>
     </NuxtLayout>
   </div>
 </template>
 
 <script setup lang="ts">
-import { DateTime } from 'luxon'
-import type { Rfc } from '../../../generated/red-client'
-import { useRfcEditorHead } from '~/utilities/head'
-import { safeJsonParse } from '~/utilities/json'
-import { fetchRetry } from '~/utilities/network'
 import { parseRFCId } from '~/utilities/rfc'
-import { rfcToRfcCommon } from '~/utilities/rfc-converters'
-import { RfcBucketHtmlDocumentSchema } from '~/utilities/rfc-validators'
-import {
-  apiRfcDocRetrievePathBuilder,
-  apiRfcBucketDocumentURLBuilder,
-  infoRfcPathBuilder,
-  rfcFormatPathBuilder,
-  PUBLIC_SITE
-} from '~/utilities/url'
 
 const route = useRoute()
 const paramsId = route.params.id
@@ -55,76 +33,16 @@ if (paramsId === undefined) {
   })
 }
 
-const id = parseRFCId(paramsId.toString())
-const rfcNumber = parseInt(id.number, 10)
-const sanitisedId = `${id.type}${rfcNumber}`
+const rfcId = parseRFCId(paramsId.toString())
 
-const {
-  data: rfcDocRetrieve,
-  status: rfcDocRetrieveStatus,
-  error: rfcDocRetrieveError
-} = await useAsyncData<Rfc>(`info-docretrieve-${sanitisedId}`, async () =>
-  $fetch(apiRfcDocRetrievePathBuilder(rfcNumber))
-)
-
-const rfc = computed(() => {
-  if (!rfcDocRetrieve.value) return
-  return rfcToRfcCommon(rfcDocRetrieve.value)
-})
-
-const { data: rfcBucketHtmlDocument, error: rfcBucketHtmlDocumentError } = await useAsyncData(
-  `info-buckethtmldocument-${sanitisedId}`,
-  async () => {
-    const url = apiRfcBucketDocumentURLBuilder(rfcNumber)
-    const response = await fetchRetry(url)
-    if (!response.ok) {
-      throw Error(`${response.status}: ${response.statusText} ${url}`)
-    }
-    const text = await response.text()
-    const maybeRfcBucketDocument = safeJsonParse(text)
-    if (typeof maybeRfcBucketDocument !== 'object') {
-      const errorTitle = `Expected JSON object from ${url} but received ${typeof maybeRfcBucketDocument}`
-      console.log(errorTitle, maybeRfcBucketDocument)
-      throw Error(`${errorTitle}. See console for more.`)
-    }
-    const { data, error } = RfcBucketHtmlDocumentSchema.safeParse(maybeRfcBucketDocument)
-    if (error) {
-      console.log('Failed to validate', JSON.stringify(maybeRfcBucketDocument, null, 2), error)
-      throw error
-    }
-    return data
-  })
-
-if (rfcDocRetrieveError.value) {
-  console.error(rfcDocRetrieveError.value, rfcBucketHtmlDocumentError.value)
+if (rfcId.type !== 'RFC') {
+  console.error(`Unsupported info param of ${paramsId}`)
   throw createError({
     statusCode: 404,
-    statusMessage: 'Not Found',
+    statusMessage: `No ${paramsId} content found.`,
     fatal: true
   })
 }
-
-if (rfcBucketHtmlDocumentError.value) {
-  console.error(rfcBucketHtmlDocumentError.value)
-  throw createError({
-    statusCode: 404,
-    statusMessage: `No ${sanitisedId} content found. If this is a new RFC please try again later. Try also ${PUBLIC_SITE}${rfcFormatPathBuilder(sanitisedId, 'html')}`,
-    fatal: true
-  })
-}
-
-const canonicalUrl = infoRfcPathBuilder(sanitisedId)
-
-useRfcEditorHead({
-  title: rfcDocRetrieve.value?.title ?? '',
-  canonicalUrl,
-  description: rfcDocRetrieve.value?.abstract ?? '',
-  modifiedDateTime:
-    rfcDocRetrieve.value?.published ?
-      DateTime.fromISO(rfcDocRetrieve.value.published)
-      : undefined,
-  contentType: 'article'
-})
 
 definePageMeta({
   layout: false

--- a/client/app/utilities/head.ts
+++ b/client/app/utilities/head.ts
@@ -46,7 +46,11 @@ const formatTitle = (title?: string) => {
   if (!title) {
     return SITE_NAME
   }
-  return `${title} | ${SITE_NAME}`
+  return `${title} | ${SITE_NAME}`.replace(
+    // remove linebreaks
+    /\s/g,
+    ' '
+  )
 }
 
 const linkPreviewImageBuilder = (mode: 'opengraph' | 'twitter') => {

--- a/client/app/utilities/rfc.ts
+++ b/client/app/utilities/rfc.ts
@@ -66,7 +66,7 @@ export const blankRfcCommon: RfcCommon = {
   text: ''
 }
 
-type RFCId = {
+export type RFCId = {
   type: string | typeof RFC_TYPE_RFC
   number: string
   title?: string


### PR DESCRIPTION
## chore

* to support non-RFC info pages (eg https://www.rfc-editor.org/info/bcp10 ) this refactors `/info/[id].vue` RFC loading into `RFCDocument.vue`, so that we can have a BCP loading etc in the future