### PR TITLE
fix: PDF and HorizontalScrollable

### DIFF
--- a/client/app/components/HorizontalScrollable.vue
+++ b/client/app/components/HorizontalScrollable.vue
@@ -37,8 +37,6 @@ const scrollContainer = useTemplateRef('scroll-container')
 const canScrollLeft = ref(false)
 const canScrollRight = ref(false)
 
-const afterContentClass = " after:content-[_] "
-
 const BUFFER_PX = 8
 
 let timer: ReturnType<typeof setTimeout>

--- a/client/app/components/HorizontalScrollable.vue
+++ b/client/app/components/HorizontalScrollable.vue
@@ -1,22 +1,24 @@
 <template>
-  <component
-    :is="props.as"
-    ref="scroll-container"
-    :class="[
-      'w-full max-w-[calc(100vw_-_var(--rfc-editor-org-scrollbar-width,16px))] overflow-x-auto transition-shadow duration-800',
-      props.class,
-      {
-        'shadow-[inset_70px_0px_90px_-70px_rgba(0,_45,_60,_0.5),inset_36px_0px_20px_-36px_rgba(0,_45,_60,_0.5)] dark:shadow-[inset_70px_0px_90px_-70px_rgba(140,_201,_222,_0.5),inset_36px_0px_20px_-36px_rgba(140,_201,_222,_0.5)]':
-          canScrollLeft && !canScrollRight,
-        'shadow-[inset_-70px_0px_90px_-70px_rgba(0,_45,_60,_0.5),inset_-36px_0px_20px_-36px_rgba(0,_45,_60,_0.5)] dark:shadow-[inset_-70px_0px_90px_-70px_rgba(140,_201,_222,_0.5),inset_-36px_0px_20px_-36px_rgba(140,_201,_222,_0.5)]':
-          !canScrollLeft && canScrollRight,
-        'shadow-[inset_70px_0px_90px_-70px_rgba(0,_45,_60,_0.5),inset_-70px_0px_90px_-70px_rgba(0,_45,_60,_0.5)] dark:shadow-[inset_70px_0px_90px_-70px_rgba(140,_201,_222,_0.5),inset_-70px_0px_90px_-70px_rgba(140,_201,_222,_0.5)]':
-          canScrollLeft && canScrollRight
-      }]"
-    @scroll="debouncedUpdateScrollHint"
+  <div
+    class="after:content-['_'] after:absolute after:left-0 after:top-0 after:w-full after:h-full after:pointer-events-none after:transition-shadow after:duration-800 "
+    :class="{
+      'after:shadow-[inset_70px_0px_90px_-70px_rgba(0,_45,_60,_0.5),inset_36px_0px_20px_-36px_rgba(0,_45,_60,_0.5)] dark:shadow-[inset_70px_0px_90px_-70px_rgba(140,_201,_222,_0.5),inset_36px_0px_20px_-36px_rgba(140,_201,_222,_0.5)]':
+        canScrollLeft && !canScrollRight,
+      'after:w-[100px] after:shadow-[inset_-70px_0px_90px_-70px_rgba(0,_45,_60,_0.5),inset_-36px_0px_20px_-36px_rgba(0,_45,_60,_0.5)] dark:shadow-[inset_-70px_0px_90px_-70px_rgba(140,_201,_222,_0.5),inset_-36px_0px_20px_-36px_rgba(140,_201,_222,_0.5)]':
+        !canScrollLeft && canScrollRight,
+      'after:shadow-[inset_70px_0px_90px_-70px_rgba(0,_45,_60,_0.5),inset_-70px_0px_90px_-70px_rgba(0,_45,_60,_0.5)] dark:shadow-[inset_70px_0px_90px_-70px_rgba(140,_201,_222,_0.5),inset_-70px_0px_90px_-70px_rgba(140,_201,_222,_0.5)]':
+        canScrollLeft && canScrollRight
+    }"
   >
-    <slot />
-  </component>
+    <component
+      :is="props.as"
+      ref="scroll-container"
+      :class="`relative w-full max-w-[calc(100vw_-_var(--rfc-editor-org-scrollbar-width,16px))] overflow-x-auto  ${props.class}`"
+      @scroll="debouncedUpdateScrollHint"
+    >
+      <slot />
+    </component>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -34,6 +36,8 @@ const props = withDefaults(defineProps<Props>(), { 'as': 'div' })
 const scrollContainer = useTemplateRef('scroll-container')
 const canScrollLeft = ref(false)
 const canScrollRight = ref(false)
+
+const afterContentClass = " after:content-[_] "
 
 const BUFFER_PX = 8
 

--- a/client/app/components/RFCDocumentBody.vue
+++ b/client/app/components/RFCDocumentBody.vue
@@ -98,6 +98,7 @@ import { infoRfcPathBuilder } from '~/utilities/url'
 import type { BreadcrumbItem } from '~/components/BreadcrumbsTypes'
 import type { DocumentPojo, ElementPojo, NodePojo } from '~/utilities/rfc-validators'
 import { COMMA, NONBREAKING_SPACE } from '~/utilities/strings'
+import { nodePojoWalker } from '~/utilities/dom'
 
 type Props = {
   rfc: RfcCommon
@@ -202,7 +203,16 @@ const renderDocumentPojo = (nodes: DocumentPojo): VNode => {
         console.log("Found pdf pages")
         return h(
           HorizontalScrollable,
-          node.attributes,
+          {
+            ...node.attributes,
+            class: 'py-6',
+            children: nodePojoWalker(node.children, (node) => {
+              if (node.type === 'Element') {
+                node.attributes['class'] = 'w-[425px] lg:w-auto'
+              }
+              return node
+            })
+          },
           () => childrenForVue
         )
       }

--- a/client/app/utilities/dom.ts
+++ b/client/app/utilities/dom.ts
@@ -1,3 +1,5 @@
+import type { NodePojo } from './rfc-validators'
+
 /**
  * W3C DOMParser factory that works on server and browser
  */
@@ -79,4 +81,24 @@ export const getInnerText = (element: HTMLElement): string => {
       return ''
     })
     .join('')
+}
+
+type NodeReplacementFn = (node: NodePojo) => NodePojo
+
+/**
+ * Walks a NodePojo and Provides a callback for
+ */
+export const nodePojoWalker = (
+  nodes: NodePojo[],
+  reviver: NodeReplacementFn
+): NodePojo[] => {
+  return nodes.map((node) => {
+    const newNode = reviver(node)
+
+    if (newNode.type === 'Element') {
+      newNode.children = nodePojoWalker(newNode.children, reviver)
+    }
+
+    return newNode
+  })
 }


### PR DESCRIPTION
## fix

* HorizontalScrolalble would animate a CSS `box-shadow` on the scrollable div which only worked when the content was transparent. There were SVGs with bugs in RFCs that had solid white areas that broke the illusion of a shadow. This instead draws the shadow ontop with `pointer-events:none` for click-through

## feat

* Improvements to PDF RFCs responsive behaviour. Test with eg RFC418