### PR TITLE
fix: parse status

### DIFF
--- a/client/app/utilities/rfc-converter-parse.ts
+++ b/client/app/utilities/rfc-converter-parse.ts
@@ -96,6 +96,6 @@ export const parseRfcStreamSlug = (
     case 'legacy':
       return 'Legacy'
   }
-  
+
   throw Error(`Unable to parse stream slug "${streamSlug}"`)
 }

--- a/client/app/utilities/rfc-converter-parse.ts
+++ b/client/app/utilities/rfc-converter-parse.ts
@@ -88,6 +88,7 @@ export const parseRfcStreamSlug = (
       return 'IAB'
     case 'irtf':
       return 'IRTF'
+    case 'ise':
     case 'independent':
       return 'INDEPENDENT'
     case 'editorial':
@@ -95,5 +96,6 @@ export const parseRfcStreamSlug = (
     case 'legacy':
       return 'Legacy'
   }
+  
   throw Error(`Unable to parse stream slug "${streamSlug}"`)
 }


### PR DESCRIPTION
## fix

* the parse status slug didn't handle `ise`