### PR TITLE
feat: errata search redirect scaffolding

### DIFF
--- a/client/app/middleware/complexRedirects.global.ts
+++ b/client/app/middleware/complexRedirects.global.ts
@@ -30,7 +30,6 @@ export default defineNuxtRouteMiddleware((to, _from) => {
     const middlewareRedirect = middlewareRedirects[i]
     assertIsDefined(middlewareRedirect)
     const isMatch = middlewareRedirect[0].test(to.fullPath)
-    console.log("middlware", isMatch, middlewareRedirect)
     if (isMatch) {
       const newPath = to.fullPath.replace(
         middlewareRedirect[0],

--- a/client/app/middleware/complexRedirects.global.ts
+++ b/client/app/middleware/complexRedirects.global.ts
@@ -30,6 +30,7 @@ export default defineNuxtRouteMiddleware((to, _from) => {
     const middlewareRedirect = middlewareRedirects[i]
     assertIsDefined(middlewareRedirect)
     const isMatch = middlewareRedirect[0].test(to.fullPath)
+    console.log("middlware", isMatch, middlewareRedirect)
     if (isMatch) {
       const newPath = to.fullPath.replace(
         middlewareRedirect[0],

--- a/client/app/utilities/legacy-errata-search-redirect.test.ts
+++ b/client/app/utilities/legacy-errata-search-redirect.test.ts
@@ -1,0 +1,14 @@
+// @vitest-environment nuxt
+import { test, expect } from 'vitest'
+import { legacyErrataSearchRedirectPathBuilder } from './legacy-errata-search-redirect'
+import { RFC_EDITOR_ERRATA_SEARCH_URL } from './url'
+
+test('translateParamsString: just a redirect', () => {
+  expect(legacyErrataSearchRedirectPathBuilder('?')).toEqual(RFC_EDITOR_ERRATA_SEARCH_URL)
+  expect(legacyErrataSearchRedirectPathBuilder('/errata_search.php?')).toEqual(RFC_EDITOR_ERRATA_SEARCH_URL)
+  expect(legacyErrataSearchRedirectPathBuilder('/errata_search.php')).toEqual(RFC_EDITOR_ERRATA_SEARCH_URL)
+})
+
+test('translateParamsString: rfc number', () => {
+  expect(legacyErrataSearchRedirectPathBuilder('?rfc=9000')).toEqual(`${RFC_EDITOR_ERRATA_SEARCH_URL}?rfc=9000`)
+})

--- a/client/app/utilities/legacy-errata-search-redirect.test.ts
+++ b/client/app/utilities/legacy-errata-search-redirect.test.ts
@@ -1,14 +1,14 @@
 // @vitest-environment nuxt
 import { test, expect } from 'vitest'
-import { legacyErrataSearchRedirectPathBuilder } from './legacy-errata-search-redirect'
+import { legacyErrataSearchRedirectUrlBuilder } from './legacy-errata-search-redirect'
 import { RFC_EDITOR_ERRATA_SEARCH_URL } from './url'
 
 test('translateParamsString: just a redirect', () => {
-  expect(legacyErrataSearchRedirectPathBuilder('?')).toEqual(RFC_EDITOR_ERRATA_SEARCH_URL)
-  expect(legacyErrataSearchRedirectPathBuilder('/errata_search.php?')).toEqual(RFC_EDITOR_ERRATA_SEARCH_URL)
-  expect(legacyErrataSearchRedirectPathBuilder('/errata_search.php')).toEqual(RFC_EDITOR_ERRATA_SEARCH_URL)
+  expect(legacyErrataSearchRedirectUrlBuilder('?')).toEqual(RFC_EDITOR_ERRATA_SEARCH_URL)
+  expect(legacyErrataSearchRedirectUrlBuilder('/errata_search.php?')).toEqual(RFC_EDITOR_ERRATA_SEARCH_URL)
+  expect(legacyErrataSearchRedirectUrlBuilder('/errata_search.php')).toEqual(RFC_EDITOR_ERRATA_SEARCH_URL)
 })
 
 test('translateParamsString: rfc number', () => {
-  expect(legacyErrataSearchRedirectPathBuilder('?rfc=9000')).toEqual(`${RFC_EDITOR_ERRATA_SEARCH_URL}?rfc=9000`)
+  expect(legacyErrataSearchRedirectUrlBuilder('?rfc=9000')).toEqual(`${RFC_EDITOR_ERRATA_SEARCH_URL}?rfc=9000`)
 })

--- a/client/app/utilities/legacy-errata-search-redirect.ts
+++ b/client/app/utilities/legacy-errata-search-redirect.ts
@@ -54,7 +54,7 @@ const LegacyErrataSearchParamsSchema = z.object({
     .optional()
 })
 
-export const legacyErrataSearchRedirectPathBuilder = (url: string): string => {
+export const legacyErrataSearchRedirectUrlBuilder = (url: string): string => {
   // FIXME: ensure the redirect works correctly (the target doesn't exist yet)
 
   const legacyURLParams = new URL(url, 'https://localhost/').searchParams

--- a/client/app/utilities/legacy-errata-search-redirect.ts
+++ b/client/app/utilities/legacy-errata-search-redirect.ts
@@ -1,0 +1,116 @@
+import { z } from 'zod'
+import {
+  RFC_EDITOR_ERRATA_SEARCH_URL,
+  typeSenseEncodeUriComponent
+} from './url'
+
+const LegacyErrataSearchParamsSchema = z.object({
+  rfc: z.string().optional(), // RFC number
+  eid: z.string().optional(), // Errata ID
+  title: z.string().optional(),
+  rec_status: z
+    .union([
+      z.literal('15'), // All/Any
+      z.literal('0'), // Verified+Reported
+      z.literal('1'), // Verified
+      z.literal('2'), // Reported
+      z.literal('3'), // Held for Document Update
+      z.literal('9') // Rejected
+    ])
+    .optional(),
+  errata_type: z
+    .union([
+      z.literal(''), // All/Any
+      z.literal('2') // Technical
+    ])
+    .optional(),
+  area_acronym: z
+    .union([
+      z.literal(''), // All/Any
+      z.literal('app'),
+      z.literal('art'),
+      z.literal('gen'),
+      z.literal('int'),
+      z.literal('ops'),
+      z.literal('rai'),
+      z.literal('rtg'),
+      z.literal('sec'),
+      z.literal('tsv'),
+      z.literal('wit')
+    ])
+    .optional(),
+  wg_acronym: z.string().optional(),
+  submitter_name: z.string().optional(),
+  submit_date: z.string().optional(),
+  stream_name: z
+    .union([
+      z.literal(''), // All/Any
+      z.literal('IAB'),
+      z.literal('INDEPENDENT'),
+      z.literal('IRTF'),
+      z.literal('Legacy'),
+      z.literal('Editorial')
+    ])
+    .optional()
+})
+
+export const legacyErrataSearchRedirectPathBuilder = (url: string): string => {
+  // FIXME: ensure the redirect works correctly (the target doesn't exist yet)
+
+  const legacyURLParams = new URL(url, 'https://localhost/').searchParams
+  const legacyObj: Record<string, string | string[]> = {}
+
+  // convert URL into object so we can validate it
+  for (const [key, value] of legacyURLParams.entries()) {
+    if (Object.prototype.hasOwnProperty.call(legacyObj, key)) {
+      const legacyObjValue = legacyObj[key]
+      if (typeof legacyObjValue === 'string') {
+        legacyObj[key] = [legacyObjValue]
+      }
+      if (!Array.isArray(legacyObj[key])) {
+        throw Error(`Expected array but was ${typeof legacyObj[key]}`)
+      }
+      legacyObj[key].push(value)
+    } else {
+      legacyObj[key] = value
+    }
+  }
+
+  const legacySearchParams = LegacyErrataSearchParamsSchema.safeParse(legacyObj)
+
+  if (legacySearchParams.data) {
+    return buildSearchRedirect(legacySearchParams.data)
+  }
+
+  return RFC_EDITOR_ERRATA_SEARCH_URL
+}
+
+type LegacyErrataSearchParams = z.infer<typeof LegacyErrataSearchParamsSchema>
+
+export const buildSearchRedirect = (
+  legacyErrataSearchObj: z.infer<typeof LegacyErrataSearchParamsSchema>
+): string => {
+  const hasParams =
+    Object.values(legacyErrataSearchObj).join('').trim().length > 0
+
+  const params =
+    hasParams ?
+      Object.keys(legacyErrataSearchObj)
+        .sort() // normalize order
+        .map((searchKey) => {
+          const typesenseSearchKey = searchKey
+          const searchValue =
+            legacyErrataSearchObj[searchKey as keyof LegacyErrataSearchParams]
+
+          return searchValue ?
+              `${encodeURIComponent(typesenseSearchKey)}=${typeSenseEncodeUriComponent(
+                Array.isArray(searchValue) ? searchValue.join(',') : searchValue
+              )}`
+            : ''
+        })
+        .filter(Boolean)
+        .join('&')
+    : ''
+
+  return `${RFC_EDITOR_ERRATA_SEARCH_URL}${params ? '?' : ''}${params}`
+}

--- a/client/app/utilities/legacy-search-redirect.ts
+++ b/client/app/utilities/legacy-search-redirect.ts
@@ -21,6 +21,7 @@ export const legacySearchRedirectPathBuilder = (url: string): string => {
   const legacyURLParams = new URL(url, 'https://localhost/').searchParams
   const legacyObj: Record<string, string | string[]> = {}
 
+  // convert URL into object so we can validate it
   for (const [key, value] of legacyURLParams.entries()) {
     if (Object.prototype.hasOwnProperty.call(legacyObj, key)) {
       const legacyObjValue = legacyObj[key]

--- a/client/app/utilities/url.ts
+++ b/client/app/utilities/url.ts
@@ -58,7 +58,7 @@ export const INTERNET_SOCIETY_URL = 'https://www.internetsociety.org'
 export const MATERIALS_URL = 'https://materials.rfc-editor.org'
 export const IAD_URL = 'https://iad.rfc-editor.org'
 export const DASHBOARD_URL = 'https://dashboard.rfc-editor.org'
-
+export const RFC_EDITOR_ERRATA_SEARCH_URL = 'https://errata.rfc-editor.org/search/'
 export const SEARCH_PATH = '/search/'
 
 export const API_HOMEPAGE_LATEST_PATH = `/api/v1/homepage-latest.json`
@@ -386,5 +386,5 @@ export const parseMaybeRfcLink = (
  *  * RFC 1866
  *  * https://stackoverflow.com/a/29948396
  */
-const typeSenseEncodeUriComponent = (uriComponent: string) =>
+export const typeSenseEncodeUriComponent = (uriComponent: string) =>
   encodeURIComponent(uriComponent).replace(/%20/g, '+')

--- a/client/server/routes/errata_search.php.ts
+++ b/client/server/routes/errata_search.php.ts
@@ -1,0 +1,20 @@
+import { legacyErrataSearchRedirectPathBuilder } from '~/utilities/legacy-errata-search-redirect'
+import { SEARCH_PATH } from '~/utilities/url'
+
+const HTTP_301_PERMANENT_REDIRECT = 301
+
+/**
+ * Redirect from the old URL of /search/errata.php
+ * to the new path of /search/
+ * while translating all the params (that's the hard bit..see adjacent tests)
+ */
+export default defineEventHandler(async (event) => {
+  const url = getRequestURL(event)
+  const params = legacyErrataSearchRedirectPathBuilder(url.search)
+
+  sendRedirect(
+    event,
+    `${SEARCH_PATH}${params ? `?${params}` : ''}`,
+    HTTP_301_PERMANENT_REDIRECT
+  )
+})

--- a/client/server/routes/errata_search.php.ts
+++ b/client/server/routes/errata_search.php.ts
@@ -1,20 +1,13 @@
-import { legacyErrataSearchRedirectPathBuilder } from '~/utilities/legacy-errata-search-redirect'
-import { SEARCH_PATH } from '~/utilities/url'
+import { legacyErrataSearchRedirectUrlBuilder } from '~/utilities/legacy-errata-search-redirect'
 
 const HTTP_301_PERMANENT_REDIRECT = 301
 
 /**
  * Redirect from the old URL of /search/errata.php
- * to the new path of /search/
- * while translating all the params (that's the hard bit..see adjacent tests)
+ * to the new path of errata.rfc-editor.org
  */
 export default defineEventHandler(async (event) => {
   const url = getRequestURL(event)
-  const params = legacyErrataSearchRedirectPathBuilder(url.search)
-
-  sendRedirect(
-    event,
-    `${SEARCH_PATH}${params ? `?${params}` : ''}`,
-    HTTP_301_PERMANENT_REDIRECT
-  )
+  const newUrl = legacyErrataSearchRedirectUrlBuilder(url.search)
+  sendRedirect(event, newUrl, HTTP_301_PERMANENT_REDIRECT)
 })


### PR DESCRIPTION
## feat

* initial scaffolding of the [legacy errata search](https://www.rfc-editor.org/errata_search.php?eid=55&area_acronym=int) redirect to the new errata site. A FIXME has been added to remind a review before launch.