### PR TITLE
fix: contact at ietf meeting link. chore: using URL constants

### DIFF
--- a/client/app/components/FooterNavData.ts
+++ b/client/app/components/FooterNavData.ts
@@ -1,3 +1,12 @@
+import {
+  CONTACT_PATH,
+  DATATRACKER_URL,
+  IETF_URL,
+  INTERNET_DRAFT_AUTHOR_RESOURCES_URL,
+  INTERNET_SOCIETY_URL,
+  IRTF_URL
+} from '~/utilities/url'
+
 type MenuItem = {
   label: string
   children: { label: string; href: string }[]
@@ -7,20 +16,20 @@ export const menuData: MenuItem[] = [
   {
     label: 'Useful links',
     children: [
-      { label: 'IETF.org', href: 'https://www.ietf.org/' },
-      { label: 'IRTF.org', href: 'https://www.irtf.org/' },
-      { label: 'Datatracker', href: 'https://datatracker.ietf.org/' },
+      { label: 'IETF.org', href: IETF_URL },
+      { label: 'IRTF.org', href: IRTF_URL },
+      { label: 'Datatracker', href: DATATRACKER_URL },
       {
         label: 'Internet-Draft Author Resources',
-        href: 'https://authors.ietf.org/'
+        href: INTERNET_DRAFT_AUTHOR_RESOURCES_URL
       },
-      { label: 'Internet Society', href: 'https://www.internetsociety.org/' }
+      { label: 'Internet Society', href: INTERNET_SOCIETY_URL }
     ]
   },
   {
     label: 'Contact Us',
     children: [
-      { label: 'RFC Editor at IETF', href: '/contact/at-ietf/' },
+      { label: 'RFC Editor at IETF', href: CONTACT_PATH },
       {
         label: 'rfc-dist Info Page',
         href: 'http://mailman.rfc-editor.org/mailman/listinfo/rfc-dist'

--- a/client/app/utilities/url.ts
+++ b/client/app/utilities/url.ts
@@ -58,7 +58,9 @@ export const INTERNET_SOCIETY_URL = 'https://www.internetsociety.org'
 export const MATERIALS_URL = 'https://materials.rfc-editor.org'
 export const IAD_URL = 'https://iad.rfc-editor.org'
 export const DASHBOARD_URL = 'https://dashboard.rfc-editor.org'
+export const INTERNET_DRAFT_AUTHOR_RESOURCES_URL = 'https://authors.ietf.org/'
 
+export const CONTACT_PATH = '/about/contact/'
 export const SEARCH_PATH = '/search/'
 
 export const API_HOMEPAGE_LATEST_PATH = `/api/v1/homepage-latest.json`
@@ -87,7 +89,6 @@ export const ALL_CLUSTERS_PATH = '/all_clusters/'
 export const STATUS_CHANGES_PATH = '/status-changes/'
 
 export const FIXME_IEN_INDEX_PATH = '/ien/ien-index/'
-export const FIXME_CONTACT_AT_IETF_PATH = '/contact/at-ietf/'
 export const FIXME_REPORTS_SUBPUB_STATS_PATH = '/reports/subpub_stats/'
 export const FIXME_RFCS_PER_YEAR_PATH = '/rfcs-per-year/'
 export const FIXME_ERRATA_DEFINITIONS_PATH = '/errata-definitions/'
@@ -115,7 +116,6 @@ export const API_ROUTES_TO_PRERENDER = [
  */
 const _FIXME_URLS = [
   FIXME_IEN_INDEX_PATH,
-  FIXME_CONTACT_AT_IETF_PATH,
   FIXME_REPORTS_SUBPUB_STATS_PATH,
   FIXME_RFCS_PER_YEAR_PATH,
   FIXME_ERRATA_DEFINITIONS_PATH,

--- a/client/content/about/contact.md
+++ b/client/content/about/contact.md
@@ -11,7 +11,6 @@
 - To report a vulnerability in our infrastructure or services: [Vulnerability Disclosure Statement](https://www.ietf.org/about/administration/policies-procedures/vulnerability-disclosure/)
 - To report a copyright infringement: [Copyright Infringement](#report-a-copyright-infringement)
 - To make a legal request: [Legal request procedures](https://www.ietf.org/administration/legal-request-procedures/)
-- To find us at an IETF meeting, see [RFC Editor at IETF](/contact/at-ietf/).
 
 ## Report a Copyright Infringement
 


### PR DESCRIPTION
## fix

* Per agenda notes the legacy `/contact/at-ietf/` link should just be changed to `/about/contact`

## chore

* update various URLs to use constants