### PR TITLE
fix: errata list ordering

### DIFF
--- a/website/app/components/ErrataList.vue
+++ b/website/app/components/ErrataList.vue
@@ -53,7 +53,7 @@ import { countBy } from 'es-toolkit'
 import { isSelectElement } from '~/utilities/dom'
 import {
   errataItemToErrataItemForTab,
-  sortSectionIds,
+  sortErrataItemForTab,
   type ErrataItemForTab
 } from '~/utilities/errata'
 import {
@@ -115,7 +115,6 @@ onMounted(() => {
     return
   }
 
-  // mutate errataItemForTab by removing domIds that have no target in the DOM
   orderedErrataItemsForTab.value = errataItemsForTab.value
     .map((errataItemForTab) => {
       if (!errataItemForTab.domId) {
@@ -124,12 +123,12 @@ onMounted(() => {
 
       try {
         // because we derive domId from `section` it's quite possible that domId
-        // has invalid syntax for a DOM id (eg it might have whitespace), and
+        // has invalid syntax for a DOM id (it might have whitespace), and
         // getElementById() might throw
         const target = document.getElementById(errataItemForTab.domId)
         if (target) {
           // then it's a valid domId with a target so keep the domId
-          // and add the target
+          // and add the element
           return {
             ...errataItemForTab,
             domTarget: target
@@ -158,65 +157,6 @@ onMounted(() => {
         domId: undefined
       }
     })
-    .sort((a, b) => {
-      if (a.domId && b.domId) {
-        console.log('NEW Sorting', a.domId, b.domId)
-        if (!a.domTarget || !b.domTarget) {
-          console.error(
-            'Internal error - any domId should have an associated domTarget by now'
-          )
-        } else {
-          console.log('Sorting by DOM')
-          // Because this JS runs in the browser we have visibility of the RFC in the DOM
-          // so attempt to order by the DOM order so that (eg) Section 1 can be followed
-          // by Table 1 and then Section 2
-          if (
-            // Although TS insists that compareDocumentPosition always exists
-            // older browsers won't support it so we'll check first
-            // maybe this can be removed in the future but it seems harmless
-            a.domTarget.compareDocumentPosition
-          ) {
-            const order = a.domTarget.compareDocumentPosition(b.domTarget)
-            console.log(' - Sorting by DOM returned ', order)
-            if (
-              order === Node.DOCUMENT_POSITION_PRECEDING ||
-              order === Node.DOCUMENT_POSITION_CONTAINS
-            ) {
-              return 1
-            } else if (
-              order === Node.DOCUMENT_POSITION_FOLLOWING ||
-              order === Node.DOCUMENT_POSITION_CONTAINED_BY
-            ) {
-              return -1
-            } else if (order === 0) {
-              return 0
-            }
-          }
-        }
-
-        if (a.domId.startsWith('section') && b.domId.startsWith('section')) {
-          const domIdSort = sortSectionIds(a.domId, b.domId)
-          console.log('Sorting by domId', domIdSort)
-        }
-
-        if (a.domId.startsWith('section')) {
-          return -1
-        }
-
-        if (b.domId.startsWith('section')) {
-          return 1
-        }
-      }
-
-      if (a.domId && !b.domId) {
-        return -1
-      }
-
-      if (!a.domId && b.domId) {
-        return 1
-      }
-
-      return 0
-    })
+    .sort(sortErrataItemForTab)
 })
 </script>

--- a/website/app/components/ErrataListItem.vue
+++ b/website/app/components/ErrataListItem.vue
@@ -44,6 +44,19 @@
         <Heading level="4" style-level="6">Notes:</Heading>
         <component :is="notes_nodes" />
       </div>
+      <p>
+        <Anchor
+          :href="errataUrlBuilder(props.errataItemForTab.errata_id)"
+          :class="ANCHOR_TAILWIND_STYLE"
+          :aria-label="`View errata report ${props.errataItemForTab.errata_id} on the IETF Errata site`"
+        >
+          View this report
+          <Icon
+            name="fluent:window-new-20-regular"
+            class="text-lg align-middle ml-1"
+          />
+        </Anchor>
+      </p>
     </div>
   </details>
 </template>
@@ -52,6 +65,7 @@
 import { ANCHOR_TAILWIND_STYLE } from '~/utilities/theme'
 import { preformattedTextToHtml } from '~/utilities/html'
 import type { ErrataItemForTab } from '~/utilities/errata'
+import { errataUrlBuilder } from '~/utilities/url'
 
 type Props = {
   errataItemForTab: ErrataItemForTab

--- a/website/app/components/RFCTabs.vue
+++ b/website/app/components/RFCTabs.vue
@@ -433,7 +433,7 @@
         </p>
         <p class="border-b-1 border-gray-200 py-6 mb-4">
           <Anchor
-            :href="RFC_EDITOR_ERRATA_SUBSITE_URL"
+            :href="ERRATA_URL_ORIGIN"
             class="bg-blue-300 text-white dark:bg-blue-800 border-0 text-sm no-underline hover:underline focus:underline rounded my-2 p-3 font-bold"
           >
             Report a new erratum
@@ -465,7 +465,7 @@ import { ANCHOR_TAILWIND_STYLE } from '~/utilities/theme'
 import {
   areaGroupUrlBuilder,
   datatrackerAuthorUrlBuilder,
-  RFC_EDITOR_ERRATA_SUBSITE_URL,
+  ERRATA_URL_ORIGIN,
   rfcFormatPathBuilder,
   streamUrlBuilder,
   workingGroupUrlBuilder

--- a/website/app/utilities/errata.test.ts
+++ b/website/app/utilities/errata.test.ts
@@ -11,9 +11,14 @@ test('sortSectionIds: simple', () => {
 test('sortSectionIds: bad section ids', () => {
   expect(sortSectionIds('section-', 'section-')).toEqual(0)
   expect(sortSectionIds('section-..', 'section-..')).toEqual(0)
+
+  expect(sortSectionIds('section-1.2.', 'section-..')).toEqual(-1)
+  expect(sortSectionIds('section-.....', 'section-1.2.')).toEqual(1)
 })
 
 test('sortSectionIds: complex', () => {
+  expect(sortSectionIds('section-1', 'section-1.2.3')).toEqual(-1)
+  expect(sortSectionIds('section-1.2.3', 'section-1')).toEqual(1)
   expect(sortSectionIds('section-1.1', 'section-1.2')).toEqual(-1)
   expect(sortSectionIds('section-1.2', 'section-1.1')).toEqual(1)
   expect(sortSectionIds('section-1.1', 'section-1.1')).toEqual(0)

--- a/website/app/utilities/errata.ts
+++ b/website/app/utilities/errata.ts
@@ -47,6 +47,93 @@ export const errataItemToErrataItemForTab = (
   }
 }
 
+/**
+ * Sorts errataItemForTab using DOM apis (this shouldn't run on the server)
+ */
+export const sortErrataItemForTab = (
+  a: ErrataItemForTab,
+  b: ErrataItemForTab
+): number => {
+  // Errata items refer to RFC content so the list should be sorted to match
+  // the order of the RFC itself where possible.
+  //
+  // Sometimes this is not possible because the `section` is undefined.
+  // Otherwise the `section` is a string with no formal constraints.
+  //
+  // The `domId` is derived from the `section` so further examples will use
+  // the normalized `domId`. `domId` can have these kinds of values:
+  //
+  //   * `undefined`
+  //   * "1" (referring to section 1)
+  //   * "1.2.3" (referring to section 1.2.3)
+  //   * "Table 2" (referring to Table 2)
+  //
+  // Although the section examples can compare "1" to "1.2.3" by extracting the
+  // numbers in the string, this doesn't work for "Table 2" which could appear
+  // anywhere in the RFC.
+  //
+  // Because of this our sorting strategy is to look for DOM elements and sort
+  // by DOM position, and then fallback to extracting numbers in the string.
+  //
+  // If the domId is undefined it's sorted to the end.
+
+  if (a.domId && b.domId) {
+    if (!a.domTarget || !b.domTarget) {
+      throw Error(
+        '[sortErrataItemForTab] internal error, any domId should have an associated domTarget by now'
+      )
+    }
+    // Because this JS runs in the browser we have visibility of the RFC in the DOM
+    // so attempt to order by the DOM order so that (eg) Section 1 can be followed
+    // by Table 1 and then Section 2
+    if (
+      // Although TS insists that compareDocumentPosition always exists
+      // older browsers won't support it so we'll check first
+      // maybe this can be removed in the future but it seems harmless
+      a.domTarget.compareDocumentPosition
+    ) {
+      const order = a.domTarget.compareDocumentPosition(b.domTarget)
+      console.log(' - Sorting by DOM returned ', order)
+      if (
+        order === Node.DOCUMENT_POSITION_PRECEDING ||
+        order === Node.DOCUMENT_POSITION_CONTAINS
+      ) {
+        return 1
+      } else if (
+        order === Node.DOCUMENT_POSITION_FOLLOWING ||
+        order === Node.DOCUMENT_POSITION_CONTAINED_BY
+      ) {
+        return -1
+      } else if (order === 0) {
+        return 0
+      }
+    }
+
+    if (a.domId.startsWith('section') && b.domId.startsWith('section')) {
+      const domIdSort = sortSectionIds(a.domId, b.domId)
+      console.log('Sorting by domId', domIdSort)
+    }
+
+    if (a.domId.startsWith('section')) {
+      return -1
+    }
+
+    if (b.domId.startsWith('section')) {
+      return 1
+    }
+  }
+
+  if (a.domId && !b.domId) {
+    return -1
+  }
+
+  if (!a.domId && b.domId) {
+    return 1
+  }
+
+  return 0
+}
+
 export const sortSectionIds = (a: string, b: string): number => {
   const aNums = a
     .replace(/[^0-9.]/gi, '')
@@ -63,14 +150,21 @@ export const sortSectionIds = (a: string, b: string): number => {
     const aNum = aNums[i]
     const bNum = bNums[i]
 
-    if (Number.isNaN(aNum) || Number.isNaN(bNum)) {
-      return 0
+    if (!Number.isNaN(aNum) && Number.isNaN(bNum)) {
+      return -1
     }
-    if (aNum === undefined && bNum !== undefined) {
+    if (Number.isNaN(aNum) && !Number.isNaN(bNum)) {
       return 1
     }
-    if (aNum !== undefined && bNum === undefined) {
+    if (Number.isNaN(aNum) && Number.isNaN(bNum)) {
+      return 0
+    }
+
+    if (aNum === undefined && bNum !== undefined) {
       return -1
+    }
+    if (aNum !== undefined && bNum === undefined) {
+      return 1
     }
     if (aNum === undefined || bNum === undefined) {
       return 0

--- a/website/app/utilities/url.ts
+++ b/website/app/utilities/url.ts
@@ -50,13 +50,14 @@ export const DATATRACKER_URL_ORIGIN = 'https://datatracker.ietf.org'
 export const IETF_URL_ORIGIN = 'https://www.ietf.org'
 export const IRTF_URL_ORIGIN = 'https://www.irtf.org'
 export const IAB_URL_ORIGIN = 'https://www.iab.org'
+export const ERRATA_URL_ORIGIN = 'https://errata.rfc-editor.org'
 export const INTERNET_SOCIETY_URL_ORIGIN = 'https://www.internetsociety.org'
 export const MATERIALS_URL_ORIGIN = 'https://materials.rfc-editor.org'
 export const IAD_URL_ORIGIN = 'https://iad.rfc-editor.org'
 export const DASHBOARD_URL_ORIGIN = 'https://dashboard.rfc-editor.org'
 export const INTERNET_DRAFT_AUTHOR_RESOURCES_URL_ORIGIN =
   'https://authors.ietf.org'
-export const RFC_EDITOR_ERRATA_SUBSITE_URL = 'https://errata.rfc-editor.org/'
+
 export const RFC_EDITOR_ERRATA_SEARCH_URL =
   'https://errata.rfc-editor.org/search/'
 export const IETF_PRIVACY_STATEMENT_URL =
@@ -393,6 +394,10 @@ export const workingGroupUrlBuilder = (workingGroup: RfcCommon['group']) => {
   if (!workingGroup) return undefined
   // See https://github.com/ietf-tools/red/issues/179
   return `${DATATRACKER_URL_ORIGIN}/wg/${workingGroup.acronym}/about/` as const
+}
+
+export const errataUrlBuilder = (errataId: string) => {
+  return `${ERRATA_URL_ORIGIN}/${errataId}/` as const
 }
 
 export const areaGroupUrlBuilder = (area: RfcCommon['area']) => {


### PR DESCRIPTION
## fix

* sort errata by DOM location and `section` id

_screenshots_
**before**
<img width="299" height="623" alt="Screenshot from 2026-03-20 16-11-40" src="https://github.com/user-attachments/assets/3f6b8387-94ae-44a4-bb61-0df2125f5330" />

**after**
<img width="299" height="623" alt="Screenshot from 2026-03-20 16-34-22" src="https://github.com/user-attachments/assets/c5bac1de-4fc4-4f8f-9033-5f4a89e7a4b6" />
