### PR TITLE
feat: Rfc organisation as author

### DIFF
--- a/precomputer/src/tasks/__snapshots__/rfc-ref-txt.test.ts.snap
+++ b/precomputer/src/tasks/__snapshots__/rfc-ref-txt.test.ts.snap
@@ -252,7 +252,7 @@ exports[`renderInNotesRfcRefDotTxt > compare against 5 digit-wide rendering (RFC
  RFC4047 |            | Wells, D. and S. Allen, "MIME Sub-type Registrations for Flexible Image Transport System (FITS)", RFC 4047, DOI 10.17487/RFC4047, April 2005, <https://www.rfc-editor.org/info/rfc4047/>.
  RFC4048 |            | Carpenter, B., "RFC 1888 Is Obsolete", RFC 4048, DOI 10.17487/RFC4048, April 2005, <https://www.rfc-editor.org/info/rfc4048/>.
  RFC4049 |    RFC6019 | Housley, R., "BinaryTime: An Alternate Format for Representing Date and Time in ASN.1", RFC 4049, DOI 10.17487/RFC4049, April 2005, <https://www.rfc-editor.org/info/rfc4049/>.
- RFC5000 |    RFC7100 | Editor, R., "Internet Official Protocol Standards", RFC 5000, DOI 10.17487/RFC5000, May 2008, <https://www.rfc-editor.org/info/rfc5000/>.
+ RFC5000 |    RFC7100 | RFC Editor, "Internet Official Protocol Standards", RFC 5000, DOI 10.17487/RFC5000, May 2008, <https://www.rfc-editor.org/info/rfc5000/>.
  RFC5001 |            | Austein, R., "DNS Name Server Identifier (NSID) Option", RFC 5001, DOI 10.17487/RFC5001, August 2007, <https://www.rfc-editor.org/info/rfc5001/>.
  RFC5002 |            | Camarillo, G. and G. Blanco, "The Session Initiation Protocol (SIP) P-Profile-Key Private Header (P-Header)", RFC 5002, DOI 10.17487/RFC5002, August 2007, <https://www.rfc-editor.org/info/rfc5002/>.
  RFC5003 |            | Balus, F., Martini, L., Metz, C., and J. Sugimoto, "Attachment Individual Identifier (AII) Types for Aggregation", RFC 5003, DOI 10.17487/RFC5003, September 2007, <https://www.rfc-editor.org/info/rfc5003/>.
@@ -757,7 +757,7 @@ RFC4046 |           | Canetti, R., Dondeti, L., Lindholm, F., and M. Baugher, "M
 RFC4047 |           | Wells, D. and S. Allen, "MIME Sub-type Registrations for Flexible Image Transport System (FITS)", RFC 4047, DOI 10.17487/RFC4047, April 2005, <https://www.rfc-editor.org/info/rfc4047/>.
 RFC4048 |           | Carpenter, B., "RFC 1888 Is Obsolete", RFC 4048, DOI 10.17487/RFC4048, April 2005, <https://www.rfc-editor.org/info/rfc4048/>.
 RFC4049 |   RFC6019 | Housley, R., "BinaryTime: An Alternate Format for Representing Date and Time in ASN.1", RFC 4049, DOI 10.17487/RFC4049, April 2005, <https://www.rfc-editor.org/info/rfc4049/>.
-RFC5000 |   RFC7100 | Editor, R., "Internet Official Protocol Standards", RFC 5000, DOI 10.17487/RFC5000, May 2008, <https://www.rfc-editor.org/info/rfc5000/>.
+RFC5000 |   RFC7100 | RFC Editor, "Internet Official Protocol Standards", RFC 5000, DOI 10.17487/RFC5000, May 2008, <https://www.rfc-editor.org/info/rfc5000/>.
 RFC5001 |           | Austein, R., "DNS Name Server Identifier (NSID) Option", RFC 5001, DOI 10.17487/RFC5001, August 2007, <https://www.rfc-editor.org/info/rfc5001/>.
 RFC5002 |           | Camarillo, G. and G. Blanco, "The Session Initiation Protocol (SIP) P-Profile-Key Private Header (P-Header)", RFC 5002, DOI 10.17487/RFC5002, August 2007, <https://www.rfc-editor.org/info/rfc5002/>.
 RFC5003 |           | Balus, F., Martini, L., Metz, C., and J. Sugimoto, "Attachment Individual Identifier (AII) Types for Aggregation", RFC 5003, DOI 10.17487/RFC5003, September 2007, <https://www.rfc-editor.org/info/rfc5003/>.

--- a/precomputer/src/tasks/rfc-ref-txt.ts
+++ b/precomputer/src/tasks/rfc-ref-txt.ts
@@ -100,7 +100,7 @@ const stringifyRFC = (rfc: RfcCommon): string => {
 
     doi = formatIdentifiers(rfc.identifiers, ' ').join(' ')
 
-    return `${formatAuthorsPerStyleGuide(rfc.authors)}, "${rfc.title}", ${also}RFC ${rfc.number}, ${doi},${rfcdate ? ` ${rfcdate},` : ''
+    return `${formatAuthorsPerStyleGuide(rfc.authors, 'brief')}, "${rfc.title}", ${also}RFC ${rfc.number}, ${doi},${rfcdate ? ` ${rfcdate},` : ''
       } <${PUBLIC_SITE_URL_ORIGIN}/info/rfc${rfc.number}/>.`
   }
 }

--- a/precomputer/src/tasks/rfc.ts
+++ b/precomputer/src/tasks/rfc.ts
@@ -177,7 +177,16 @@ export const uploadRefsRef = async (rfcNumber: number): AsyncTaskItem => {
   const rfcRefS3Path = rfcRefPathBuilder(rfcNumber)
   if (
     // https://github.com/ietf-tools/red/issues/354
-    [212, 1370, 1602].includes(rfc.number)
+    [
+      212,
+      1359,
+      1370,
+      1602,
+      2223,
+      2850,
+
+
+    ].includes(rfc.number)
   ) {
     console.log(`[RFC ${rfc.number}] debug ${rfcRefS3Path} ${JSON.stringify(rfc)}`)
   }

--- a/precomputer/src/tasks/rfc.ts
+++ b/precomputer/src/tasks/rfc.ts
@@ -184,8 +184,6 @@ export const uploadRefsRef = async (rfcNumber: number): AsyncTaskItem => {
       1602,
       2223,
       2850,
-
-
     ].includes(rfc.number)
   ) {
     console.log(`[RFC ${rfc.number}] debug ${rfcRefS3Path} ${JSON.stringify(rfc)}`)

--- a/precomputer/src/utilities/authors.ts
+++ b/precomputer/src/utilities/authors.ts
@@ -1,5 +1,5 @@
 import { type RfcCommon } from "../../../website/app/utilities/rfc-validators.ts";
-import { EDITOR_SUFFIX, formatAuthor } from "./rfc-converters-utils.ts";
+import { EDITOR_SUFFIX, formatAuthor, type FormatAuthorStyle } from "./rfc-converters-utils.ts";
 
 if (
   // @ts-ignore TS thinks .escape doesn't exist but it should
@@ -18,9 +18,9 @@ const editorSuffixRegex = new RegExp(`${
  * https://www.rfc-editor.org/styleguide/part2/#ref_rfcs
  * https://www.rfc-editor.org/authors/rfc-style-guide/
  */
-export const formatAuthorsPerStyleGuide = (authors: RfcCommon["authors"]): string => {
+export const formatAuthorsPerStyleGuide = (authors: RfcCommon["authors"], formatAuthorStyle: FormatAuthorStyle = 'brief'): string => {
   return authors.map((author, index, arr) => {
-    const formattedName = formatAuthor(author, 'brief')
+    const formattedName = formatAuthor(author, formatAuthorStyle)
     const hasTwoAuthors = arr.length === 2
     const hasMultipleAuthors = arr.length > 1
 

--- a/precomputer/src/utilities/rfc-converters-utils.ts
+++ b/precomputer/src/utilities/rfc-converters-utils.ts
@@ -6,6 +6,8 @@ type RfcAuthor = RfcCommon['authors'][number]
 
 export const EDITOR_SUFFIX = ', Ed.'
 
+export type FormatAuthorStyle = 'regular' | 'brief' | 'reverse'
+
 /**
  * Formats author names into an initialised format.
  *
@@ -18,10 +20,57 @@ export const EDITOR_SUFFIX = ', Ed.'
  */
 export const formatAuthor = (
   author: RfcAuthor,
-  style: 'regular' | 'brief' | 'reverse'
+  style: FormatAuthorStyle
 ): string => {
   const { titlepage_name } = author
   if (!titlepage_name) return ''
+
+  const organisationsAsUsers = [
+    'Information Sciences Institute University of Southern California', // RFC 212
+    'International Telegraph and Telephone Consultative Committee of the International Telecommunication Union', // RFC 804
+    'National Bureau of Standards', // RFC 806, RFC 841
+    'International Organization for Standardization', // RFC 892, RFC 926, RFC 941, RFC 994, RFC 995
+    'ISO', // RFC 905
+    'Bolt Beranek and Newman Laboratories', // RFC 907
+    'National Research Council', // RFC 939, RFC 942
+    'Gateway Algorithms and Data Structures Task Force', // RFC 940
+    'National Science Foundation', // RFC 985
+    'Network Technical Advisory Group', // RFC 985
+    'NetBIOS Working Group in the Defense Advanced Research Projects Agency', // RFC 1001, RFC 1002
+    'Internet Activities Board', // RFC 1001, RFC 1002, RFC 1083, RFC 1087, RFC 1100, RFC 1130, RFC 1140, RFC 1200
+    'End-to-End Services Task Force', // RFC 1001, RFC 1002
+    'Sun Microsystems', // RFC 1014, RFC 1050, RFC 1057, RFC 2339
+    'Defense Advanced Research Projects Agency', // RFC 1087, RFC 1100, RFC 1130, RFC 1140, RFC 1200
+    'North American Directory Forum', // RFC 1218
+    'The North American Directory Forum', // RFC 1255, RFC 1295, RFC 1417, RFC 1758
+    'ESCC X.500/X.400 Task Force', // RFC 1330
+    'Energy Sciences Network (ESnet)', // RFC 1330
+    'ESnet Site Coordinating Comittee (ESCC)', // RFC 1330 (note: typo "Comittee" is in the source data)
+    'ACM SIGUCCS', // RFC 1359
+    'Internet Architecture Board', // RFC 1370, RFC 1401, RFC 1602, RFC 2826, RFC 2850, RFC 3677, RFC 3869, RFC 4052, RFC 4844, RFC 4845, RFC 6220
+    'Vietnamese Standardization Working Group', // RFC 1456
+    'Internet Engineering Steering Group', // RFC 1517, RFC 1602
+    'EARN Staff', // RFC 1580
+    'RARE WG-MSG Task Force 88', // RFC 1616
+    'IETF Secretariat', // RFC 1718
+    'Internet Assigned Numbers Authority (IANA)', // RFC 1797
+    'Federal Networking Council', // RFC 1811, RFC 1816, RFC 2146
+    'IAB', // RFC 1881, RFC 1984, RFC 2804, RFC 2825, RFC 3177, RFC 3245, RFC 3424, RFC 3639, RFC 3724, RFC 4101, RFC 4367, RFC 4440, RFC 4690, RFC 4732, RFC 5507, RFC 5620, RFC 5694, RFC 5704, RFC 5741, RFC 5745, RFC 6548, RFC 6635
+    'IESG', // RFC 1881, RFC 1984, RFC 2804, RFC 3177
+    'Audio-Video Transport Working Group', // RFC 1889, RFC 1890
+    'ISOC Board of Trustees', // RFC 2134, RFC 2135
+    'KOI8-U Working Group', // RFC 2319
+    'The Internet Society', // RFC 2339
+    'IANA', // RFC 3330
+    'IAB Advisory Committee', // RFC 3716
+    'IAB and IESG', // RFC 4089
+    'RFC Editor', // RFC 5000, RFC 5540
+  ]
+
+  if (organisationsAsUsers.includes(titlepage_name)) {
+    return titlepage_name
+  }
+
   const name = titlepage_name
     .split(/[\s.]/g)
     .filter(Boolean)

--- a/precomputer/src/utilities/rfc-converters-utils.ts
+++ b/precomputer/src/utilities/rfc-converters-utils.ts
@@ -6,6 +6,51 @@ type RfcAuthor = RfcCommon['authors'][number]
 
 export const EDITOR_SUFFIX = ', Ed.'
 
+/**
+ * No longer done, but some early RFCs had authors as organisations not individuals.
+ */
+const organisationsAsUsers = [
+  'Information Sciences Institute University of Southern California', // RFC 212
+  'International Telegraph and Telephone Consultative Committee of the International Telecommunication Union', // RFC 804
+  'National Bureau of Standards', // RFC 806, RFC 841
+  'International Organization for Standardization', // RFC 892, RFC 926, RFC 941, RFC 994, RFC 995
+  'ISO', // RFC 905
+  'Bolt Beranek and Newman Laboratories', // RFC 907
+  'National Research Council', // RFC 939, RFC 942
+  'Gateway Algorithms and Data Structures Task Force', // RFC 940
+  'National Science Foundation', // RFC 985
+  'Network Technical Advisory Group', // RFC 985
+  'NetBIOS Working Group in the Defense Advanced Research Projects Agency', // RFC 1001, RFC 1002
+  'Internet Activities Board', // RFC 1001, RFC 1002, RFC 1083, RFC 1087, RFC 1100, RFC 1130, RFC 1140, RFC 1200
+  'End-to-End Services Task Force', // RFC 1001, RFC 1002
+  'Sun Microsystems', // RFC 1014, RFC 1050, RFC 1057, RFC 2339
+  'Defense Advanced Research Projects Agency', // RFC 1087, RFC 1100, RFC 1130, RFC 1140, RFC 1200
+  'North American Directory Forum', // RFC 1218
+  'The North American Directory Forum', // RFC 1255, RFC 1295, RFC 1417, RFC 1758
+  'ESCC X.500/X.400 Task Force', // RFC 1330
+  'Energy Sciences Network (ESnet)', // RFC 1330
+  'ESnet Site Coordinating Comittee (ESCC)', // RFC 1330 (note: typo "Comittee" is in the source data)
+  'ACM SIGUCCS', // RFC 1359
+  'Internet Architecture Board', // RFC 1370, RFC 1401, RFC 1602, RFC 2826, RFC 2850, RFC 3677, RFC 3869, RFC 4052, RFC 4844, RFC 4845, RFC 6220
+  'Vietnamese Standardization Working Group', // RFC 1456
+  'Internet Engineering Steering Group', // RFC 1517, RFC 1602
+  'EARN Staff', // RFC 1580
+  'RARE WG-MSG Task Force 88', // RFC 1616
+  'IETF Secretariat', // RFC 1718
+  'Internet Assigned Numbers Authority (IANA)', // RFC 1797
+  'Federal Networking Council', // RFC 1811, RFC 1816, RFC 2146
+  'IAB', // RFC 1881, RFC 1984, RFC 2804, RFC 2825, RFC 3177, RFC 3245, RFC 3424, RFC 3639, RFC 3724, RFC 4101, RFC 4367, RFC 4440, RFC 4690, RFC 4732, RFC 5507, RFC 5620, RFC 5694, RFC 5704, RFC 5741, RFC 5745, RFC 6548, RFC 6635
+  'IESG', // RFC 1881, RFC 1984, RFC 2804, RFC 3177
+  'Audio-Video Transport Working Group', // RFC 1889, RFC 1890
+  'ISOC Board of Trustees', // RFC 2134, RFC 2135
+  'KOI8-U Working Group', // RFC 2319
+  'The Internet Society', // RFC 2339
+  'IANA', // RFC 3330
+  'IAB Advisory Committee', // RFC 3716
+  'IAB and IESG', // RFC 4089
+  'RFC Editor', // RFC 5000, RFC 5540
+]
+
 export type FormatAuthorStyle = 'regular' | 'brief' | 'reverse'
 
 /**
@@ -24,48 +69,6 @@ export const formatAuthor = (
 ): string => {
   const { titlepage_name } = author
   if (!titlepage_name) return ''
-
-  const organisationsAsUsers = [
-    'Information Sciences Institute University of Southern California', // RFC 212
-    'International Telegraph and Telephone Consultative Committee of the International Telecommunication Union', // RFC 804
-    'National Bureau of Standards', // RFC 806, RFC 841
-    'International Organization for Standardization', // RFC 892, RFC 926, RFC 941, RFC 994, RFC 995
-    'ISO', // RFC 905
-    'Bolt Beranek and Newman Laboratories', // RFC 907
-    'National Research Council', // RFC 939, RFC 942
-    'Gateway Algorithms and Data Structures Task Force', // RFC 940
-    'National Science Foundation', // RFC 985
-    'Network Technical Advisory Group', // RFC 985
-    'NetBIOS Working Group in the Defense Advanced Research Projects Agency', // RFC 1001, RFC 1002
-    'Internet Activities Board', // RFC 1001, RFC 1002, RFC 1083, RFC 1087, RFC 1100, RFC 1130, RFC 1140, RFC 1200
-    'End-to-End Services Task Force', // RFC 1001, RFC 1002
-    'Sun Microsystems', // RFC 1014, RFC 1050, RFC 1057, RFC 2339
-    'Defense Advanced Research Projects Agency', // RFC 1087, RFC 1100, RFC 1130, RFC 1140, RFC 1200
-    'North American Directory Forum', // RFC 1218
-    'The North American Directory Forum', // RFC 1255, RFC 1295, RFC 1417, RFC 1758
-    'ESCC X.500/X.400 Task Force', // RFC 1330
-    'Energy Sciences Network (ESnet)', // RFC 1330
-    'ESnet Site Coordinating Comittee (ESCC)', // RFC 1330 (note: typo "Comittee" is in the source data)
-    'ACM SIGUCCS', // RFC 1359
-    'Internet Architecture Board', // RFC 1370, RFC 1401, RFC 1602, RFC 2826, RFC 2850, RFC 3677, RFC 3869, RFC 4052, RFC 4844, RFC 4845, RFC 6220
-    'Vietnamese Standardization Working Group', // RFC 1456
-    'Internet Engineering Steering Group', // RFC 1517, RFC 1602
-    'EARN Staff', // RFC 1580
-    'RARE WG-MSG Task Force 88', // RFC 1616
-    'IETF Secretariat', // RFC 1718
-    'Internet Assigned Numbers Authority (IANA)', // RFC 1797
-    'Federal Networking Council', // RFC 1811, RFC 1816, RFC 2146
-    'IAB', // RFC 1881, RFC 1984, RFC 2804, RFC 2825, RFC 3177, RFC 3245, RFC 3424, RFC 3639, RFC 3724, RFC 4101, RFC 4367, RFC 4440, RFC 4690, RFC 4732, RFC 5507, RFC 5620, RFC 5694, RFC 5704, RFC 5741, RFC 5745, RFC 6548, RFC 6635
-    'IESG', // RFC 1881, RFC 1984, RFC 2804, RFC 3177
-    'Audio-Video Transport Working Group', // RFC 1889, RFC 1890
-    'ISOC Board of Trustees', // RFC 2134, RFC 2135
-    'KOI8-U Working Group', // RFC 2319
-    'The Internet Society', // RFC 2339
-    'IANA', // RFC 3330
-    'IAB Advisory Committee', // RFC 3716
-    'IAB and IESG', // RFC 4089
-    'RFC Editor', // RFC 5000, RFC 5540
-  ]
 
   if (organisationsAsUsers.includes(titlepage_name)) {
     return titlepage_name


### PR DESCRIPTION
## feat

* When formatting authors add an allowlist of organisation names that bypass person name formatting, otherwise the names get mangled