### PR TITLE
feat: homepage search redirirect

### DIFF
--- a/website/app/components/SearchBox.vue
+++ b/website/app/components/SearchBox.vue
@@ -12,25 +12,49 @@
 <script setup lang="ts">
 import { parseSeriesId } from '~/utilities/rfc'
 import { SEARCH_PLACEHOLDER } from '~/utilities/search'
-import { infoSeriesPathBuilder, SEARCH_PATH, searchPathBuilder } from '~/utilities/url'
+import { apiRfcBucketDocumentPathBuilder, apiSubseriesPathBuilder, infoSeriesPathBuilder, SEARCH_PATH, searchPathBuilder, useApiV1UrlOrigin } from '~/utilities/url'
+
+const apiV1UrlOrigin = useApiV1UrlOrigin()
 
 const searchQuery = ref('')
 
-const handleSearch = () => {
+const handleSearch = async () => {
   const { value } = searchQuery
-  const normalizedValue = value.trim()
+  const normalizedValue = value.trim().replace(/\s/g, '')
   if (normalizedValue.match(/^[0-9]+$/)) {
     // if it's just a number assume they want to go to an RFC
     const rfcNumber = parseInt(normalizedValue, 10)
     if (rfcNumber > 0) {
-      navigateTo(infoSeriesPathBuilder(`rfc${rfcNumber}`))
-      return
+      const rfcDataPath = apiRfcBucketDocumentPathBuilder(rfcNumber)
+      try {
+        const maybeRfcBucketDocument = await $fetch(rfcDataPath, {
+          method: 'GET',
+          baseURL: import.meta.server ? apiV1UrlOrigin : undefined,
+        })
+        if (maybeRfcBucketDocument) {
+          await navigateTo(infoSeriesPathBuilder(`rfc${rfcNumber}`))
+          return
+        }
+      } catch (e: unknown) {
+        console.info(`[Homepage search] RFC ${rfcNumber} doesn't exist so using search`, rfcDataPath, normalizedValue, value, e)
+      }
     }
   }
   const seriesId = parseSeriesId(normalizedValue)
   if (seriesId) {
-    navigateTo(infoSeriesPathBuilder(`${seriesId.type}${seriesId.number}`))
-    return
+    const subseriesPath = apiSubseriesPathBuilder(seriesId.type, seriesId.number)
+    try {
+      const maybeSubseriesDocument = await $fetch(subseriesPath, {
+        method: 'GET',
+        baseURL: import.meta.server ? apiV1UrlOrigin : undefined,
+      })
+      if (maybeSubseriesDocument) {
+        await navigateTo(infoSeriesPathBuilder(`${seriesId.type}${seriesId.number}`))
+        return
+      }
+    } catch (e: unknown) {
+      console.info(`[Homepage search] ${seriesId.type} ${seriesId.number} doesn't exist so using search`, subseriesPath, normalizedValue, value, e)
+    }
   }
 
   const searchPath = searchPathBuilder({

--- a/website/app/components/SearchBox.vue
+++ b/website/app/components/SearchBox.vue
@@ -10,12 +10,29 @@
 </template>
 
 <script setup lang="ts">
+import { parseSeriesId } from '~/utilities/rfc'
 import { SEARCH_PLACEHOLDER } from '~/utilities/search'
-import { SEARCH_PATH, searchPathBuilder } from '~/utilities/url'
+import { infoSeriesPathBuilder, SEARCH_PATH, searchPathBuilder } from '~/utilities/url'
 
 const searchQuery = ref('')
 
 const handleSearch = () => {
+  const { value } = searchQuery
+  const normalizedValue = value.trim()
+  if (normalizedValue.match(/^[0-9]+$/)) {
+    // if it's just a number assume they want to go to an RFC
+    const rfcNumber = parseInt(normalizedValue, 10)
+    if (rfcNumber > 0) {
+      navigateTo(infoSeriesPathBuilder(`rfc${rfcNumber}`))
+      return
+    }
+  }
+  const seriesId = parseSeriesId(normalizedValue)
+  if (seriesId) {
+    navigateTo(infoSeriesPathBuilder(`${seriesId.type}${seriesId.number}`))
+    return
+  }
+
   const searchPath = searchPathBuilder({
     q: searchQuery.value
   })

--- a/website/app/components/SubseriesDocument.vue
+++ b/website/app/components/SubseriesDocument.vue
@@ -1,10 +1,7 @@
 <template>
   <BodyLayoutDocument>
     <template #sidebar>
-      <div
-        v-if="subseriesDocument"
-        class="lg:min-w-[300px]"
-      >
+      <div v-if="subseriesDocument" class="lg:min-w-[300px]">
         <p v-if="subseriesDocument.type === 'bcp'">
           BCPs are stable identifiers for Best Current Practices. A BCP may consist of a single RFC or a group of RFCs
           related to a specific IETF process or recommended guidelines.
@@ -21,28 +18,16 @@
     </template>
     <template v-if="subseriesDocumentError">
       <div class="container mx-auto">
-        <Alert
-          level="1"
-          variant="warning"
-          heading="Error"
-        >
+        <Alert level="1" variant="warning" heading="Error">
           {{ subseriesDocumentError }}
         </Alert>
       </div>
     </template>
 
     <div class="min-h-screen">
-      <div
-        v-if="subseriesDocument"
-        class="mt-3 flex flex-col gap-4"
-      >
-        <RFCCard
-          v-for="rfc in subseriesDocument.contents"
-          :key="rfc.number"
-          :rfc="rfc"
-          heading-level="3"
-          :show-abstract="true"
-        />
+      <div v-if="subseriesDocument" class="mt-3 flex flex-col gap-4">
+        <RFCCard v-for="rfc in subseriesDocument.contents" :key="rfc.number" :rfc="rfc" heading-level="3"
+          :show-abstract="true" />
       </div>
     </div>
   </BodyLayoutDocument>
@@ -76,17 +61,17 @@ const { data: subseriesDocument, error: subseriesDocumentError } = await useAsyn
   subseriesDocumentKey,
   async () => {
     const subseriesPath = apiSubseriesPathBuilder(props.subseriesId.type, props.subseriesId.number)
-    const maybeRfcBucketDocument = await $fetch(subseriesPath, {
+    const maybeSubseriesDocument = await $fetch(subseriesPath, {
       method: 'GET',
       baseURL: import.meta.server ? apiV1UrlOrigin : undefined,
     })
-    if (typeof maybeRfcBucketDocument !== 'object') {
-      console.log("Unexpected response type. The server Content-Type may be misconfigured so $fetch() doesn't parse as JSON", typeof maybeRfcBucketDocument, maybeRfcBucketDocument)
+    if (typeof maybeSubseriesDocument !== 'object') {
+      console.log("Unexpected response type. The server Content-Type may be misconfigured so $fetch() doesn't parse as JSON", typeof maybeSubseriesDocument, maybeSubseriesDocument)
       throw Error(`Unable to load RFC. See console for more.`)
     }
-    const { data, error } = SubseriesCommonSchema.safeParse(maybeRfcBucketDocument)
+    const { data, error } = SubseriesCommonSchema.safeParse(maybeSubseriesDocument)
     if (error) {
-      console.log('Failed to validate RFC HTML JSON', error, JSON.stringify(maybeRfcBucketDocument, null, 2))
+      console.log('Failed to validate RFC HTML JSON', error, JSON.stringify(maybeSubseriesDocument, null, 2))
       throw Error(`Unable to load RFC. See console for more.`)
     }
     return data

--- a/website/nuxt.config.ts
+++ b/website/nuxt.config.ts
@@ -54,9 +54,13 @@ export default defineNuxtConfig({
     optimizeDeps: {
       include: [
         'es-toolkit',
+        'es-toolkit/compat',
         'luxon',
         'zod',
-        '@vueuse/core'
+        '@vueuse/core',
+        'core-js/actual/array/to-sorted',
+        'vue-instantsearch/vue3/es',
+        'typesense-instantsearch-adapter/src/TypesenseInstantsearchAdapter.js',
       ]
     }
   },


### PR DESCRIPTION
## feat

* If on the homepage search people search for a specific RFC or BCP/etc redirect to `/info/*` rather than the search engine
  * only on the homepage search, not the search route
  * typing numbers is assumed to be an RFC number
  * verify that the page API data exists before redirecting, otherwise bail to search