### PR TITLE
fix: Re-add ISE review guidelines

### DIFF
--- a/website/content/authors/ise/ise-reviewer-guidelines.md
+++ b/website/content/authors/ise/ise-reviewer-guidelines.md
@@ -43,7 +43,7 @@ Questions that the ISE would like you to answer:
 
 - Is the subject of this document relevant to the RFC Series?  
 
-   [RFC 4846](https://www.rfc-editor.org/rfc/rfc4846.txt) provides details as to what is acceptable as an individual submission.  Generally a draft must show that it is improving overall interoperability or otherwise provide some important insight or innovation relating to the Internet.
+   [RFC 4846](/info/rfc4846) provides details as to what is acceptable as an individual submission.  Generally a draft must show that it is improving overall interoperability or otherwise provide some important insight or innovation relating to the Internet.
 
 - Is this document technically competent, as far as you can tell?
 

--- a/website/content/authors/ise/ise-reviewer-guidelines.md
+++ b/website/content/authors/ise/ise-reviewer-guidelines.md
@@ -35,7 +35,7 @@ Board (ISEB)](/authors/ise/iseb/) for their information.
 
 Unless a review is unsolicited or otherwise requested, the ISE will identify the reviewer to the author.  It is expected that the review process will be both consultative and iterative, with an eye toward improving document quality.
 
-Reviews may be posted publicly.  In requested, your anonymity will be respected.
+Reviews may be posted publicly.  If requested, your anonymity will be respected.
 
 ## Contents of Reviews
 
@@ -43,11 +43,11 @@ Questions that the ISE would like you to answer:
 
 - Is the subject of this document relevant to the RFC Series?  
 
-   [RFC 4846](https://www.rfc-editor.org/rfc/rfc4846.txt) provides details as to what is acceptable as an individual submission.  Generally a draft must show that it is improving overall interoperability or otherwise provide some important incite or innovation relating to the Internet.
+   [RFC 4846](https://www.rfc-editor.org/rfc/rfc4846.txt) provides details as to what is acceptable as an individual submission.  Generally a draft must show that it is improving overall interoperability or otherwise provide some important insight or innovation relating to the Internet.
 
 - Is this document technically competent, as far as you can tell?
 
-     Are protocols and interfaces well-specified?  Is the specification
+     Are protocols and interfaces well specified?  Is the specification
      safe and appropriate to deploy at scale?  Is the document correct?
 
 - Is this document in reasonable (not necessarily final) editorial

--- a/website/content/authors/ise/ise-reviewer-guidelines.md
+++ b/website/content/authors/ise/ise-reviewer-guidelines.md
@@ -41,47 +41,39 @@ Reviews may be posted publicly.  In requested, your anonymity will be respected.
 
 Questions that the ISE would like you to answer:
 
-<ol type="A">
-   <li>
-   Is the subject of this document relevant to the RFC Series?<br>
+- Is the subject of this document relevant to the RFC Series?  
 
-	<a ref="https://www.rfc-editor.org/rfc/rfc4846.txt">RFC 4846</a> provides details as to what is acceptable as an individual submission.
-Generally a draft must show that it is improving overall interoperability or otherwise provide some important incite or innovation relating to the Internet.
-</li>
-<li>
-   Is this document technically competent, as far as you can tell?
+   [RFC 4846](https://www.rfc-editor.org/rfc/rfc4846.txt) provides details as to what is acceptable as an individual submission.  Generally a draft must show that it is improving overall interoperability or otherwise provide some important incite or innovation relating to the Internet.
 
-   Are protocols and interfaces well-specified?  Is the specification
-   safe and appropriate to deploy at scale?  Is the document correct?
+- Is this document technically competent, as far as you can tell?
 
-</li>
-<li>Is this document in reasonable (not necessarily final) editorial 
+     Are protocols and interfaces well-specified?  Is the specification
+     safe and appropriate to deploy at scale?  Is the document correct?
+
+- Is this document in reasonable (not necessarily final) editorial
    shape?
 
-   Works should concisely and clearly make their point.  Was it easy 
-   to discern that point, and could you understand the approach being 
+   Works should concisely and clearly make their point.  Was it easy
+   to discern that point, and could you understand the approach being
    offered?  Is the document complete?
-</li>
-<li>
-   Are the abstract and introduction of this document reasonably clear?
 
-   Does the introduction provide enough background for those Internet 
+- Are the abstract and introduction of this document reasonably clear?
+
+   Does the introduction provide enough background for those Internet
    techies who may not be experts in the particular subject matter?  
-   Do the title and abstract fairly and accurately summarize the 
+   Do the title and abstract fairly and accurately summarize the
    contents?
-</li>
-<li>Does the document make clear upfront how the specification does or 
-   does not relate to past or current IETF activities?
-   <br>An independent submission <b>must not</b> mislead the reader that it is a standard.
-</li>
-<li>
-   How else can the document be improved?
 
-   Any additional suggestions that you can make to improve the quality 
-   and clarity of the document will be welcomed by the ISE and in most 
+- Does the document make clear upfront how the specification does or
+   does not relate to past or current IETF activities?  
+
+   An independent submission **must not** mislead the reader that it is a standard.
+
+- How else can the document be improved?
+
+   Any additional suggestions that you can make to improve the quality
+   and clarity of the document will be welcomed by the ISE and in most
    cases will be welcomed by the author(s).
-</li>
-</ol>
 
 ## Questions?
 

--- a/website/content/authors/ise/ise-reviewer-guidelines.md
+++ b/website/content/authors/ise/ise-reviewer-guidelines.md
@@ -85,5 +85,4 @@ Generally a draft must show that it is improving overall interoperability or oth
 
 ## Questions?
 
-Feel free to contact the ISE [rfc-ise@rfc-editor.org](mailto:rfc-ise@rfc-editor.org) with any questions 
-you may have about document reviews.
+Feel free to contact the ISE [rfc-ise@rfc-editor.org](mailto:rfc-ise@rfc-editor.org) with any questions you may have about document reviews.

--- a/website/content/authors/ise/ise-reviewer-guidelines.md
+++ b/website/content/authors/ise/ise-reviewer-guidelines.md
@@ -1,0 +1,89 @@
+---
+description: Reviewer guidelines for the Independent Submission Stream.
+---
+
+# Guidelines for Reviewers of RFC Independent Submissions
+
+## Goals
+
+The Independent Submissions Editor (ISE) generally makes a publication decision based on the preponderance of competent reviews of drafts.  As such, it's important to have good quality reviews from members of the community.
+
+An independent submission review is meant to achieve two overarching goals:
+
+1. Is the document appropriate for publication as an independent
+   submission?
+
+2. What improvements to the work should be made prior to publication?
+
+Sometimes early work is not yet ready for publication but will be.
+
+## Who may submit a review?
+
+Anyone may submit a document review at any time prior to publication
+of an RFC.  The Independent Submissions Editor (ISE) solicits specific
+individuals to review each document.  The ISE requests that solicited reviews be completed within a month.
+
+More reviews are always welcome, and are likely to improve the quality of both the documents under consideration and the series as a whole.
+
+Reviews are accepted by email by the [ISE](mailto:rfc-ise@rfc-editor.org).
+
+## Dissemination of Reviews
+
+All reviews (perhaps in summary) will be shared with the author(s),
+and many will be shared with the [Independent Submissions Editorial
+Board (ISEB)](/authors/ise/iseb/) for their information.
+
+Unless a review is unsolicited or otherwise requested, the ISE will identify the reviewer to the author.  It is expected that the review process will be both consultative and iterative, with an eye toward improving document quality.
+
+Reviews may be posted publicly.  In requested, your anonymity will be respected.
+
+## Contents of Reviews
+
+Questions that the ISE would like you to answer:
+
+<ol type="A">
+   <li>
+   Is the subject of this document relevant to the RFC Series?<br>
+
+	<a ref="https://www.rfc-editor.org/rfc/rfc4846.txt">RFC 4846</a> provides details as to what is acceptable as an individual submission.
+Generally a draft must show that it is improving overall interoperability or otherwise provide some important incite or innovation relating to the Internet.
+</li>
+<li>
+   Is this document technically competent, as far as you can tell?
+
+   Are protocols and interfaces well-specified?  Is the specification
+   safe and appropriate to deploy at scale?  Is the document correct?
+
+</li>
+<li>Is this document in reasonable (not necessarily final) editorial 
+   shape?
+
+   Works should concisely and clearly make their point.  Was it easy 
+   to discern that point, and could you understand the approach being 
+   offered?  Is the document complete?
+</li>
+<li>
+   Are the abstract and introduction of this document reasonably clear?
+
+   Does the introduction provide enough background for those Internet 
+   techies who may not be experts in the particular subject matter?  
+   Do the title and abstract fairly and accurately summarize the 
+   contents?
+</li>
+<li>Does the document make clear upfront how the specification does or 
+   does not relate to past or current IETF activities?
+   <br>An independent submission <b>must not</b> mislead the reader that it is a standard.
+</li>
+<li>
+   How else can the document be improved?
+
+   Any additional suggestions that you can make to improve the quality 
+   and clarity of the document will be welcomed by the ISE and in most 
+   cases will be welcomed by the author(s).
+</li>
+</ol>
+
+## Questions?
+
+Feel free to contact the ISE [rfc-ise@rfc-editor.org](mailto:rfc-ise@rfc-editor.org) with any questions 
+you may have about document reviews.

--- a/website/content/authors/rfc-independent-submissions.md
+++ b/website/content/authors/rfc-independent-submissions.md
@@ -103,7 +103,7 @@ The Independent Submissions Editor is ably assisted by the [Independent Submissi
 
 #### Who reviews submissions?
 
-The Independent Submissions Editor seeks review of the work through individuals who are knowledgeable about the topic discussed in the draft. Authors are encouraged to submit suggestions, but some reviews will be conducted outside of that list. The ISE often relies on the [Independent Submissions Editorial Board](/authors/ise/iseb) to provide reviews. In addition, the ISE welcomes comments from **anyone** on a draft that is being considered by the ISE.
+The Independent Submissions Editor seeks review of the work through individuals who are knowledgeable about the topic discussed in the draft. Authors are encouraged to submit suggestions, but some reviews will be conducted outside of that list. The ISE often relies on the [Independent Submissions Editorial Board](/authors/ise/iseb) to provide reviews. In addition, the ISE welcomes comments from **anyone** on a draft that is being considered by the ISE.  Information for reviewers can be found [here](/authors/ise/ise-reviewer-guidelines).
 
 #### Where can reviews be found?
 


### PR DESCRIPTION
This returns ISE reviewer guidelines to the web site.  This is a regression from the previous web site.

The guidelines have also been touched up for conciseness.