### PR TITLE
feat: add copy unfolded button for RFC 8792 folded blocks

### DIFF
--- a/precomputer/src/tasks/rfc-html-xml2rfc.test.ts
+++ b/precomputer/src/tasks/rfc-html-xml2rfc.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+import { describe, expect, test } from 'vitest'
+import { getDOMParser, isHtmlElement } from '../utilities/dom.ts'
+import { getXml2RfcRfcDocument } from './rfc-html-xml2rfc.ts'
+import {
+  RFC8792_COPY_CLASS,
+  RFC8792_COPY_UNFOLDED_ATTR,
+  RFC8792_SOURCECODE_MARKERS_ATTR
+} from '../../../website/shared/utils/rfc8792.ts'
+
+const getElementById = (nodes: Node[], id: string): HTMLElement => {
+  const element = nodes.find(
+    (node): node is HTMLElement =>
+      isHtmlElement(node) && node.getAttribute('id') === id
+  )
+
+  if (!element) {
+    throw Error(`Unable to find element ${id}`)
+  }
+
+  return element
+}
+
+describe('getXml2RfcRfcDocument RFC 8792 copy unfolded tagging', () => {
+  test('marks folded sourcecode blocks and removes upstream buttons', async () => {
+    const parser = await getDOMParser()
+    const dom = parser.parseFromString(
+      `<!doctype html>
+      <html>
+        <body>
+          <div class="sourcecode" id="folded">
+            <pre>========== NOTE: '\\' line wrapping per RFC 8792 ===========
+
+first folded line \\
+continues here
+</pre>
+            <button type="button" class="copy-unfolded">Copy unfolded</button>
+            <a href="#folded" class="pilcrow">&para;</a>
+          </div>
+          <div class="sourcecode" id="not-folded">
+            <pre>NOTE: '\\' line wrapping per RFC 8792
+This block mentions the header but does not use RFC 8792 folding.
+</pre>
+          </div>
+        </body>
+      </html>`,
+      'text/html'
+    )
+
+    const nodes = getXml2RfcRfcDocument(dom)
+    const folded = getElementById(nodes, 'folded')
+    const notFolded = getElementById(nodes, 'not-folded')
+
+    expect(folded.classList.contains(RFC8792_COPY_CLASS)).toBe(true)
+    expect(folded.getAttribute(RFC8792_COPY_UNFOLDED_ATTR)).toBe('true')
+    expect(folded.querySelector('button.copy-unfolded')).toBeNull()
+    expect(
+      folded.querySelector('[data-component="HorizontalScrollable"] pre')
+    ).toBeTruthy()
+
+    expect(notFolded.classList.contains(RFC8792_COPY_CLASS)).toBe(false)
+    expect(notFolded.hasAttribute(RFC8792_COPY_UNFOLDED_ATTR)).toBe(false)
+  })
+
+  test('marks renderer-added sourcecode markers for stripping', async () => {
+    const parser = await getDOMParser()
+    const dom = parser.parseFromString(
+      `<!doctype html>
+      <html>
+        <body>
+          <div class="sourcecode" id="marked">
+            <pre>&lt;CODE BEGINS&gt; file "marked-wrap.txt"
+NOTE: '\\' line wrapping per RFC 8792
+
+marked folded line \\
+continues here
+
+&lt;CODE ENDS&gt;</pre>
+          </div>
+        </body>
+      </html>`,
+      'text/html'
+    )
+
+    const nodes = getXml2RfcRfcDocument(dom)
+    const marked = getElementById(nodes, 'marked')
+
+    expect(marked.classList.contains(RFC8792_COPY_CLASS)).toBe(true)
+    expect(marked.getAttribute(RFC8792_SOURCECODE_MARKERS_ATTR)).toBe('true')
+  })
+})

--- a/precomputer/src/tasks/rfc-html-xml2rfc.ts
+++ b/precomputer/src/tasks/rfc-html-xml2rfc.ts
@@ -2,6 +2,13 @@ import { convertCSSUnit, parseCSSLength } from '../css-unit-converter/index.ts'
 import { getDOMParser, getInnerText, isHtmlElement } from '../utilities/dom.ts'
 import type { MaxPreformattedLineLengthSchemaType, TableOfContents } from '../../../website/app/utilities/rfc-validators.ts'
 import type { RfcAndToc } from './rfc-html.ts'
+import {
+  getRfc8792CopyText,
+  hasXml2RfcSourcecodeMarkers,
+  RFC8792_COPY_CLASS,
+  RFC8792_COPY_UNFOLDED_ATTR,
+  RFC8792_SOURCECODE_MARKERS_ATTR
+} from '../../../website/shared/utils/rfc8792.ts'
 
 type TocSections = TableOfContents['sections']
 type TocSection = TocSections[number]
@@ -161,7 +168,56 @@ export const getXml2RfcRfcDocument = (dom: Document): Node[] => {
     return true
   })
 
+  nodes.forEach(markRfc8792CopyableBlocks)
+
   return nodes.flatMap((node) => fixNodeForMobile(node))
+}
+
+const markRfc8792CopyableBlocks = (node: Node): void => {
+  if (!isHtmlElement(node)) {
+    return
+  }
+
+  const candidates: HTMLElement[] = []
+  if (node.matches('div.sourcecode, div.artwork')) {
+    candidates.push(node)
+  }
+  candidates.push(
+    ...Array.from(
+      node.querySelectorAll<HTMLElement>('div.sourcecode, div.artwork')
+    )
+  )
+
+  for (const candidate of candidates) {
+    candidate.querySelectorAll('button.copy-unfolded').forEach((button) => {
+      button.remove()
+    })
+    candidate.classList.remove(RFC8792_COPY_CLASS)
+    candidate.removeAttribute(RFC8792_COPY_UNFOLDED_ATTR)
+    candidate.removeAttribute(RFC8792_SOURCECODE_MARKERS_ATTR)
+
+    const pre = candidate.querySelector<HTMLElement>('pre')
+    if (!pre) {
+      continue
+    }
+
+    const text = getInnerText(pre)
+    const hasSourcecodeMarkers = hasXml2RfcSourcecodeMarkers(text)
+    const copyText = getRfc8792CopyText(text, {
+      stripSourcecodeMarkers: hasSourcecodeMarkers
+    })
+
+    if (!copyText) {
+      continue
+    }
+
+    candidate.classList.add(RFC8792_COPY_CLASS)
+    candidate.setAttribute(RFC8792_COPY_UNFOLDED_ATTR, 'true')
+
+    if (hasSourcecodeMarkers) {
+      candidate.setAttribute(RFC8792_SOURCECODE_MARKERS_ATTR, 'true')
+    }
+  }
 }
 
 const getHorizontalScrollable = (

--- a/website/app/components/RFC8792CopyUnfoldedButton.vue
+++ b/website/app/components/RFC8792CopyUnfoldedButton.vue
@@ -1,0 +1,48 @@
+<template>
+  <button
+    type="button"
+    class="copy-unfolded"
+    :aria-label="label"
+    @click.prevent.stop="handleClick"
+  >
+    {{ label }}
+  </button>
+</template>
+
+<script setup lang="ts">
+import { copyToClipboard } from '~/utilities/clipboard'
+
+type Props = {
+  text: string
+}
+
+const props = defineProps<Props>()
+
+const defaultLabel = 'Copy unfolded'
+const label = ref(defaultLabel)
+let resetTimer: ReturnType<typeof setTimeout> | undefined
+
+const setTemporaryLabel = (newLabel: string) => {
+  label.value = newLabel
+
+  if (resetTimer) {
+    clearTimeout(resetTimer)
+  }
+
+  resetTimer = setTimeout(() => {
+    label.value = defaultLabel
+    resetTimer = undefined
+  }, 1600)
+}
+
+const handleClick = async () => {
+  const copied = await copyToClipboard(props.text)
+  setTemporaryLabel(copied ? 'Copied' : 'Error')
+}
+
+onUnmounted(() => {
+  if (resetTimer) {
+    clearTimeout(resetTimer)
+  }
+})
+</script>

--- a/website/app/components/RFCDocumentBody.test.ts
+++ b/website/app/components/RFCDocumentBody.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment nuxt
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+import RFCDocumentBody from './RFCDocumentBody.vue'
+import type { RfcBucketHtmlDocument } from '~/utilities/rfc'
+
+const foldedBlock = [
+  "========== NOTE: '\\' line wrapping per RFC 8792 ===========",
+  '',
+  'first folded line \\',
+  'continues here',
+  ''
+].join('\n')
+
+const rfcBucketHtmlDocument: RfcBucketHtmlDocument = {
+  rfc: {
+    number: 8792,
+    title: 'Handling Long Lines in Content of Internet-Drafts and RFCs',
+    status: { slug: 'inf', name: 'informational' },
+    authors: [{ titlepage_name: 'K. Watsen' }],
+    stream: { slug: 'IETF', name: 'IETF' },
+    formats: [{ format: 'html' }]
+  },
+  tableOfContents: { title: 'Table of Contents', sections: [] },
+  documentHtmlType: 'xml2rfc',
+  documentHtmlObj: [
+    {
+      type: 'Element',
+      nodeName: 'div',
+      attributes: {
+        class: 'sourcecode has-copy-unfolded',
+        id: 'copy-unfolded-demo',
+        'data-rfc8792-copy-unfolded': 'true'
+      },
+      children: [
+        {
+          type: 'Element',
+          nodeName: 'pre',
+          attributes: {},
+          children: [{ type: 'Text', textContent: foldedBlock }]
+        }
+      ]
+    }
+  ],
+  maxPreformattedLineLength: { max: 68 },
+  timestampIso: '2026-06-04T00:00:00.000Z'
+}
+
+describe('RFCDocumentBody', () => {
+  test('renders RFC 8792 source blocks with their content and copy control', () => {
+    const wrapper = mount(RFCDocumentBody, {
+      props: {
+        rfcBucketHtmlDocument,
+        gotoErrata: () => {},
+        breadcrumbItems: [],
+        changeTab: () => {},
+        isModalOpen: false
+      },
+      global: {
+        stubs: {
+          Breadcrumbs: true,
+          RFCDocumentMobileInfoButton: {
+            template: '<button type="button"><slot /></button>'
+          },
+          Heading: {
+            props: ['level'],
+            template: '<component :is="`h${level}`"><slot /></component>'
+          },
+          RFCTitle: true,
+          RFCTitleSubseries: true,
+          RFCDocumentAuthor: true,
+          RFCDocumentBodyPill: true,
+          Alert: true,
+          RFCMobileBanner: true
+        }
+      }
+    })
+
+    const sourcecode = wrapper.get('#copy-unfolded-demo')
+
+    expect(sourcecode.get('pre').text()).toContain('first folded line \\')
+    expect(sourcecode.get('button.copy-unfolded').text()).toBe(
+      'Copy unfolded'
+    )
+  })
+})

--- a/website/app/components/RFCDocumentBody.vue
+++ b/website/app/components/RFCDocumentBody.vue
@@ -117,15 +117,22 @@
 
 <script setup lang="ts">
 import RFCTitleSubseries from './RFCTitleSubseries.vue'
+import RFC8792CopyUnfoldedButton from './RFC8792CopyUnfoldedButton.vue'
 import { isAprilFoolsRfc } from '~/utilities/rfc'
 import { infoSeriesPathBuilder } from '~/utilities/url'
 import { COMMA, NONBREAKING_SPACE, SPACE } from '~/utilities/strings'
 import type { BreadcrumbItem } from '~/components/BreadcrumbsTypes'
 import type { RfcBucketHtmlDocument } from '~/utilities/rfc'
+import type { ElementPojo, NodePojo } from '~/utilities/rfc-validators'
 import { ANCHOR_COLOR_TAILWIND_STYLE } from '~/utilities/theme'
 import { renderDocumentPojo, renderNodePojo, defaultRenderer, type ElementRenderers } from '~/utilities/renderDocumentPojo'
 import { AbsoluteHorizontalScrollable, AMaybeRFCLink, HorizontalScrollable, PdfPages } from '#components'
 import { nodePojoWalker } from '~/utilities/dom'
+import {
+  getRfc8792CopyText,
+  RFC8792_COPY_UNFOLDED_ATTR,
+  RFC8792_SOURCECODE_MARKERS_ATTR
+} from '../../shared/utils/rfc8792'
 
 type Props = {
   rfcBucketHtmlDocument: RfcBucketHtmlDocument
@@ -138,9 +145,64 @@ const props = defineProps<Props>()
 
 const isModalOpen = defineModel<boolean>('isModalOpen')
 
+const childrenForVueToArray = (childrenForVue: VNode | VNode[] | undefined): VNode[] => {
+  if (!childrenForVue) {
+    return []
+  }
+
+  return Array.isArray(childrenForVue) ? childrenForVue : [childrenForVue]
+}
+
+const getNodePojoInnerText = (node: NodePojo): string => {
+  if (node.type === 'Text') {
+    return node.textContent
+  }
+
+  return node.children.map(getNodePojoInnerText).join('')
+}
+
+const getFirstPreText = (node: ElementPojo): string | undefined => {
+  if (node.nodeName.toLowerCase() === 'pre') {
+    return node.children.map(getNodePojoInnerText).join('')
+  }
+
+  for (const child of node.children) {
+    if (child.type === 'Element') {
+      const preText = getFirstPreText(child)
+
+      if (preText !== undefined) {
+        return preText
+      }
+    }
+  }
+}
+
 const rfcHtmlPojoRenderers: ElementRenderers = {
   ...defaultRenderer,
   a: (node, childrenForVue) => h(AMaybeRFCLink, { href: '', ...node.attributes }, () => childrenForVue),
+  div: (node, childrenForVue) => {
+    if (node.attributes[RFC8792_COPY_UNFOLDED_ATTR] !== 'true') {
+      return defaultRenderer.__default(node, childrenForVue)
+    }
+
+    const preText = getFirstPreText(node)
+    const copyText =
+      preText ?
+        getRfc8792CopyText(preText, {
+          stripSourcecodeMarkers:
+            node.attributes[RFC8792_SOURCECODE_MARKERS_ATTR] === 'true'
+        })
+      : null
+
+    if (!copyText) {
+      return defaultRenderer.__default(node, childrenForVue)
+    }
+
+    return h(node.nodeName, node.attributes, [
+      ...childrenForVueToArray(childrenForVue),
+      h(RFC8792CopyUnfoldedButton, { text: copyText })
+    ])
+  },
   svg: (node, childrenForVue) => h(
     node.nodeName,
     {
@@ -236,6 +298,46 @@ const updated_by = computed(() => {
        sections.
     */
     display: none;
+  }
+
+  .has-copy-unfolded {
+    position: relative;
+  }
+
+  .copy-unfolded {
+    position: absolute;
+    top: 0.35em;
+    right: 0.35em;
+    z-index: 3;
+    opacity: 0;
+    pointer-events: none;
+    padding: 0.25em 0.5em;
+    border: 1px solid #777;
+    border-radius: 3px;
+    color: #fff;
+    background: #444;
+    font-family: var(--font-sans);
+    font-size: 0.85em;
+    line-height: 1.2;
+    cursor: pointer;
+  }
+
+  .copy-unfolded:hover,
+  .copy-unfolded:focus {
+    background: #222;
+  }
+
+  .has-copy-unfolded:hover > .copy-unfolded,
+  .has-copy-unfolded:focus-within > .copy-unfolded,
+  .copy-unfolded:focus {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  @media print {
+    .copy-unfolded {
+      display: none;
+    }
   }
 }
 

--- a/website/shared/utils/rfc8792.test.ts
+++ b/website/shared/utils/rfc8792.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest'
+import {
+  getRfc8792CopyText,
+  hasXml2RfcSourcecodeMarkers,
+  stripXml2RfcSourcecodeMarkers
+} from './rfc8792'
+
+describe('getRfc8792CopyText', () => {
+  test('unfolds the single backslash strategy', () => {
+    const text = [
+      "========== NOTE: '\\' line wrapping per RFC 8792 ===========",
+      '',
+      'first folded line \\',
+      'continues here',
+      'second folded line \\',
+      '  also continues',
+      ''
+    ].join('\n')
+
+    expect(getRfc8792CopyText(text)).toBe(
+      ['first folded line continues here', 'second folded line also continues', ''].join('\n')
+    )
+  })
+
+  test('unfolds the double backslash strategy', () => {
+    const text = [
+      "[NOTE: '\\\\' line wrapping per RFC 8792]",
+      '',
+      'first folded line \\',
+      '  \\continues here',
+      'second folded line \\',
+      '  \\also continues',
+      ''
+    ].join('\n')
+
+    expect(getRfc8792CopyText(text)).toBe(
+      ['first folded line continues here', 'second folded line also continues', ''].join('\n')
+    )
+  })
+
+  test('strips renderer-added sourcecode markers when requested', () => {
+    const text = [
+      '<CODE BEGINS> file "marked-wrap.txt"',
+      "NOTE: '\\' line wrapping per RFC 8792",
+      '',
+      'marked folded line \\',
+      'continues here',
+      '',
+      '<CODE ENDS>'
+    ].join('\n')
+
+    expect(
+      getRfc8792CopyText(text, { stripSourcecodeMarkers: true })
+    ).toBe('marked folded line continues here\n')
+  })
+
+  test('returns null when the header is present but the body is not folded', () => {
+    const text = [
+      "NOTE: '\\' line wrapping per RFC 8792",
+      '',
+      'This block mentions the header but does not use RFC 8792 folding.',
+      ''
+    ].join('\n')
+
+    expect(getRfc8792CopyText(text)).toBeNull()
+  })
+
+  test('returns null when no RFC 8792 header is present', () => {
+    expect(getRfc8792CopyText('plain source code\nline 2\n')).toBeNull()
+  })
+})
+
+describe('xml2rfc sourcecode markers', () => {
+  test('detects and strips markers', () => {
+    const text = [
+      '<CODE BEGINS>',
+      ' file "example.txt"',
+      'content',
+      '<CODE ENDS>',
+      ''
+    ].join('\n')
+
+    expect(hasXml2RfcSourcecodeMarkers(text)).toBe(true)
+    expect(stripXml2RfcSourcecodeMarkers(text)).toBe('content\n')
+  })
+})

--- a/website/shared/utils/rfc8792.ts
+++ b/website/shared/utils/rfc8792.ts
@@ -1,0 +1,166 @@
+export const RFC8792_COPY_CLASS = 'has-copy-unfolded'
+export const RFC8792_COPY_UNFOLDED_ATTR = 'data-rfc8792-copy-unfolded'
+export const RFC8792_SOURCECODE_MARKERS_ATTR = 'data-sourcecode-markers'
+
+type FoldingStrategy = 'single' | 'double'
+
+type HeaderMatch = {
+  strategy: FoldingStrategy
+  index: number
+}
+
+const headers: { strategy: FoldingStrategy; text: string }[] = [
+  { strategy: 'double', text: "NOTE: '\\\\' line wrapping per RFC 8792" },
+  { strategy: 'single', text: "NOTE: '\\' line wrapping per RFC 8792" },
+]
+
+const normaliseLineEndings = (text: string): string =>
+  text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+
+const codeBeginsPattern = /^<CODE BEGINS>(?: file "[^"]*")?$/
+const codeFileLinePattern = /^ file "[^"]*"$/
+const blankLinePattern = /^[ ]*$/
+
+const findHeader = (lines: string[]): HeaderMatch | null => {
+  for (const header of headers) {
+    const firstLine = lines[0]
+    const secondLine = lines[1]
+    const thirdLine = lines[2]
+
+    if (firstLine?.includes(header.text)) {
+      return { strategy: header.strategy, index: 0 }
+    }
+
+    if (
+      firstLine?.startsWith('<CODE BEGINS>') &&
+      secondLine?.includes(header.text)
+    ) {
+      return { strategy: header.strategy, index: 1 }
+    }
+
+    if (
+      firstLine?.startsWith('<CODE BEGINS>') &&
+      secondLine?.startsWith(' file "') &&
+      thirdLine?.includes(header.text)
+    ) {
+      return { strategy: header.strategy, index: 2 }
+    }
+  }
+
+  return null
+}
+
+const getBodyLines = (lines: string[], header: HeaderMatch): string[] => {
+  const body = lines.slice(header.index + 1)
+  const firstBodyLine = body[0]
+
+  if (firstBodyLine !== undefined && /^[ ]*$/.test(firstBodyLine)) {
+    body.shift()
+  }
+
+  return body
+}
+
+const hasFoldedLines = (
+  lines: string[],
+  strategy: FoldingStrategy
+): boolean => {
+  for (let i = 0; i < lines.length - 1; i += 1) {
+    const line = lines[i]
+    const nextLine = lines[i + 1]
+
+    if (!line?.endsWith('\\')) {
+      continue
+    }
+
+    if (strategy === 'single') {
+      return true
+    }
+
+    if (nextLine?.trimStart().startsWith('\\')) {
+      return true
+    }
+  }
+
+  return false
+}
+
+export const hasXml2RfcSourcecodeMarkers = (text: string): boolean => {
+  const lines = normaliseLineEndings(text).split('\n')
+  const firstLine = lines[0]
+  const lastContentLine = lines.findLast((line) => !blankLinePattern.test(line))
+
+  return Boolean(
+    lines.length >= 2 &&
+      firstLine !== undefined &&
+      codeBeginsPattern.test(firstLine) &&
+      lastContentLine === '<CODE ENDS>'
+  )
+}
+
+export const stripXml2RfcSourcecodeMarkers = (text: string): string => {
+  const lines = normaliseLineEndings(text).split('\n')
+  const firstLine = lines[0]
+
+  if (firstLine !== undefined && codeBeginsPattern.test(firstLine)) {
+    lines.shift()
+    const maybeFileLine = lines[0]
+
+    if (
+      maybeFileLine !== undefined &&
+      codeFileLinePattern.test(maybeFileLine)
+    ) {
+      lines.shift()
+    }
+  }
+
+  const codeEndsIndex = lines.findLastIndex((line) => !blankLinePattern.test(line))
+
+  if (lines[codeEndsIndex] === '<CODE ENDS>') {
+    lines.splice(codeEndsIndex, 1)
+  }
+
+  return lines.join('\n')
+}
+
+type Rfc8792CopyTextOptions = {
+  stripSourcecodeMarkers?: boolean
+}
+
+export const getRfc8792CopyText = (
+  text: string,
+  options: Rfc8792CopyTextOptions = {}
+): string | null => {
+  const lines = normaliseLineEndings(text).split('\n')
+  const header = findHeader(lines)
+
+  if (!header) {
+    return null
+  }
+
+  const body = getBodyLines(lines, header)
+
+  if (!hasFoldedLines(body, header.strategy)) {
+    return null
+  }
+
+  const before = lines.slice(0, header.index)
+  const headerLine = lines[header.index]
+
+  if (headerLine?.startsWith('<CODE BEGINS>')) {
+    before.push('<CODE BEGINS>')
+  }
+
+  const folded = body.join('\n')
+  const unwrapped =
+    header.strategy === 'double' ?
+      folded.replace(/\\\n[ ]*\\/g, '')
+    : folded.replace(/\\\n[ ]*/g, '')
+
+  const copyText =
+    before.length > 0 ? `${before.join('\n')}\n${unwrapped}` : unwrapped
+
+  return options.stripSourcecodeMarkers ?
+      stripXml2RfcSourcecodeMarkers(copyText)
+    : copyText
+}


### PR DESCRIPTION
Detect RFC 8792 folded blocks and add a hover/focus copy control that copies the block text unfolded.

This makes RFC 8792-folded examples usable directly from HTML RFCs: readers can copy the original unfolded source without needing to know or manually apply the folding rules.

The style, text, and accessibility attributes need some bashing and I'm happy to accomodate any requested changes.

This PR is also available for the v3 style html [here](https://github.com/ietf-tools/xml2rfc/pull/1322).

Preview:

<table>
<tr>
 <td> <img width="1294" height="768" alt="red-rfc8792-light" src="https://github.com/user-attachments/assets/815fa90f-51b8-4a5d-9b33-57e65d72046d" />
 <td> <img width="1294" height="768" alt="red-rfc8792-dark" src="https://github.com/user-attachments/assets/5f10fe10-82a3-42d6-bd80-445d5b846581" />
</table>

cc @kesara per your suggestion [here](https://github.com/ietf-tools/xml2rfc/pull/1322#issuecomment-4617354273).