### PR TITLE
feat: rewrite "how to" to explain processes in greater detail

### DIFF
--- a/website/content/authors/rfc-how-to.md
+++ b/website/content/authors/rfc-how-to.md
@@ -1,15 +1,61 @@
-# How to Write an RFC
+# How RFCs Are Created
 
-![Draft & approval via IETF or other streams → Editing by the RFC Production Center (RPC) → Official RFC publication on rfc-editor.org](/images/authors/rfc-how-to-flowchart.png)
+RFCs are the result of collaborative processes that involve writing, discussion, review, revision, and approval.
 
-RFCs all begin as [Internet-Drafts](https://authors.ietf.org/#introducing-internet-drafts) (I-Ds) that have been adopted by an [IETF working group](https://www.ietf.org/process/wgs/) or by one of the other streams for document publication.
+Documents published as RFCs begin as Internet-Drafts (I-Ds). An Internet-Draft is a working document, not an RFC, and publication as an Internet-Draft does not mean that a document has been approved or will eventually become an RFC.
 
-Each publication stream has its own processes for authoring and approving I-Ds. Refer to the [IETF](https://www.ietf.org/process/), [IRTF](https://www.irtf.org/), [IAB](https://www.iab.org/role/evaluating-new-work-proposals/), [Independent](/authors/rfc-independent-submissions/) or [Editorial](https://datatracker.ietf.org/edwg/rswg/about/) Streams for more information on how to start.
+## The IETF process
 
-Internet-Draft authors can find current authoring guidelines on the [Internet-Draft Author Resources](https://authors.ietf.org/) page.
+Most RFCs are published through the [IETF](https://www.ietf.org/) Stream. The IETF develops Internet standards and other technical documents through an open process in which participants discuss proposals, identify technical issues, review implementations and experience, and work toward consensus.
 
-When an I-D is approved for publication, it is sent to the RFC Production Center (RPC) for professional editing. The [editorial process](https://authors.ietf.org/en/rfc-publication-process) includes accuracy checks and editing for grammar, consistency, and continuity. All changes are approved by the authors before the editorial process concludes.
+Most IETF work takes place in [working groups](https://datatracker.ietf.org/wg/) focused on particular areas of Internet technology. A proposal may begin with an individual Internet-Draft and be brought to a working group for consideration. If the working group decides to take on the work, the draft may be adopted as a working group document.
 
-The official RFC is then published on rfc-editor.org. Once published, the content of an RFC does not change. However, an RFC may be obsoleted or updated (check the metadata), and [errata](/series/rfc-errata/) may be filed against them.
+Adoption is only one stage in the process. A working group document is typically discussed and revised many times as participants review its technical details and work through disagreements and open questions.
 
-You can learn more about the conventions used in RFCs on the "[Tips for Reading RFCs](/series/rfc-tips/)" page.
+**Rough consensus** is an important part of the IETF process. Decisions are not made by counting votes. Instead, working group chairs assess whether the group has reached broad agreement and whether significant technical objections have been adequately considered.
+
+Before a document can be approved for publication, it goes through additional steps which may include reviews by specialists in areas such as security, operations, internationalization, and other technical areas. Documents that advance beyond the working group receive broader IETF and Internet Engineering Steering Group ([IESG](https://www.ietf.org/about/groups/iesg/)) review.
+
+The exact path varies depending on the document and the issues that arise during review. Drafts may be substantially revised, returned for additional work, or ultimately not published.
+
+Reefer to this more detailed [overview of the IETF standards process](https://www.ietf.org/process/) for more information.
+
+### Interested in participating?
+
+The IETF process is free and open to participation. You do not need to work for a particular company or organization, and much of the work takes place asynchronously through public mailing lists. There are also three [in-person IETF meetings](https://www.ietf.org/meeting/) each year, but you do not need to attend these to participate fully.
+
+If you have an idea for a new protocol, a change to an existing technology, or another proposal that might be appropriate for the IETF, a useful first step is to learn about [Internet-Drafts and how to participate in their development](https://www.ietf.org/participate/ids/).
+
+## Other ways documents become RFCs
+
+Not every RFC is produced through the IETF standards process. The RFC Series has several publication streams, each with its own purpose and approval process.
+
+### IRTF Stream
+
+The Internet Research Task Force (IRTF) focuses on longer-term research related to the Internet. Most of its work takes place in [Research Groups](https://datatracker.ietf.org/rg/).
+
+IRTF RFCs generally report research results, describe experiments, or document technologies and ideas of interest to the Internet research community. They are not IETF standards and publication does not imply IETF consensus.
+
+[Learn more about the IRTF](https://www.irtf.org/).
+
+### Independent Stream
+
+The Independent Stream provides a path for publishing some documents that are relevant to the Internet community but are outside the IETF and IRTF publication processes.
+
+An author seeking publication through the Independent Stream first publishes an Internet-Draft and submits it to the Independent Submissions Editor (ISE). The document is evaluated and reviewed, and revisions may be required.
+
+Independent Stream RFCs do not represent IETF or community consensus and are not Internet Standards.
+
+[Learn more about Independent Submissions](/authors/rfc-independent-submissions/).
+
+## From approved draft to published RFC
+
+Regardless of publication stream, approved documents are sent to the RFC Production Center (RPC) for final editing and publication.
+
+During this process, RPC editors review the document and work with its authors to address editorial questions and improve grammar, consistency, clarity, and presentation. Authors review and approve changes and perform a final review of the document before publication.
+
+The completed document is then assigned an RFC number and officially published in the RFC Series on rfc-editor.org.
+
+## Writing an Internet-Draft
+
+Information about the required format, authoring tools, submitting drafts, and maintaining an Internet-Draft is available at [Internet-Draft Author Resources](https://authors.ietf.org/).


### PR DESCRIPTION
Expanded the document to provide a comprehensive overview of the RFC creation process, including details about the IETF, IRTF, and Independent Streams. Added sections on participation and the transition from draft to published RFC.